### PR TITLE
[#1] 인사이트 노트 댓글 기능 개발

### DIFF
--- a/src/main/java/zoo/insightnote/InsightNoteApplication.java
+++ b/src/main/java/zoo/insightnote/InsightNoteApplication.java
@@ -2,7 +2,9 @@ package zoo.insightnote;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class InsightNoteApplication {
 

--- a/src/main/java/zoo/insightnote/domain/comment/controller/CommentController.java
+++ b/src/main/java/zoo/insightnote/domain/comment/controller/CommentController.java
@@ -1,4 +1,41 @@
 package zoo.insightnote.domain.comment.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import zoo.insightnote.domain.comment.dto.CommentRequest;
+import zoo.insightnote.domain.comment.dto.CommentResponse;
+
+@Tag(name = "Comment API", description = "댓글 관련 API")
 public interface CommentController {
+
+    @Operation(summary = "댓글 작성", description = "사용자가 특정 인사이트에 댓글을 작성합니다.")
+    ResponseEntity<CommentResponse> writeComment(
+            @Parameter(description = "인사이트 ID") @PathVariable Long insightId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody CommentRequest.Create request);
+
+    @Operation(summary = "댓글 목록 조회", description = "특정 인사이트의 댓글 목록을 조회합니다.")
+    ResponseEntity<List<CommentResponse>> listComments(
+            @Parameter(description = "인사이트 ID") @PathVariable Long insightId);
+
+    @Operation(summary = "댓글 수정", description = "작성자가 본인의 댓글을 수정합니다.")
+    ResponseEntity<CommentResponse> updateComment(
+            @Parameter(description = "인사이트 ID") @PathVariable Long insightId,
+            @Parameter(description = "댓글 ID") @PathVariable Long commentId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody CommentRequest.Update request);
+
+    @Operation(summary = "댓글 삭제", description = "작성자가 본인의 댓글을 삭제합니다.")
+    ResponseEntity<CommentResponse> deleteComment(
+            @Parameter(description = "인사이트 ID") @PathVariable Long insightId,
+            @Parameter(description = "댓글 ID") @PathVariable Long commentId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails);
+
 }

--- a/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,6 +48,15 @@ public class CommentControllerImpl implements CommentController {
                                                          @RequestBody CommentRequest.Update request) {
         userDetails = validateUser(userDetails);
         CommentResponse response = commentService.updateComment(insightId, Long.valueOf(userDetails.getUsername()), commentId, request);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @DeleteMapping("/{insightId}/comments/{commentId}")
+    public ResponseEntity<CommentResponse> deleteComment(@PathVariable Long insightId,
+                                                         @PathVariable Long commentId,
+                                                         @AuthenticationPrincipal UserDetails userDetails) {
+        userDetails = validateUser(userDetails);
+        CommentResponse response = commentService.deleteComment(insightId, Long.valueOf(userDetails.getUsername()), commentId);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
@@ -27,6 +27,7 @@ public class CommentControllerImpl implements CommentController {
 
     private final CommentService commentService;
 
+    @Override
     @PostMapping("/{insightId}/comments")
     public ResponseEntity<CommentResponse> writeComment(@PathVariable Long insightId,
                                                         @AuthenticationPrincipal UserDetails userDetails,
@@ -36,11 +37,13 @@ public class CommentControllerImpl implements CommentController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Override
     @GetMapping("/{insightId}/comments")
     public ResponseEntity<List<CommentResponse>> listComments(@PathVariable Long insightId) {
         return ResponseEntity.ok().body(commentService.findCommentsByInsightId(insightId));
     }
 
+    @Override
     @PutMapping("/{insightId}/comments/{commentId}")
     public ResponseEntity<CommentResponse> updateComment(@PathVariable Long insightId,
                                                          @PathVariable Long commentId,
@@ -51,6 +54,7 @@ public class CommentControllerImpl implements CommentController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Override
     @DeleteMapping("/{insightId}/comments/{commentId}")
     public ResponseEntity<CommentResponse> deleteComment(@PathVariable Long insightId,
                                                          @PathVariable Long commentId,

--- a/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
@@ -1,9 +1,35 @@
 package zoo.insightnote.domain.comment.controller;
 
-import org.springframework.stereotype.Controller;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import zoo.insightnote.domain.comment.dto.CommentRequest.Create;
+import zoo.insightnote.domain.comment.dto.CommentResponse;
+import zoo.insightnote.domain.comment.service.CommentService;
 
-@Controller
-public class CommentControllerImpl implements CommentController{
+@RestController
+@RequestMapping("/api/v1/insights")
+@RequiredArgsConstructor
+public class CommentControllerImpl implements CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/{insightId}/comments")
+    public ResponseEntity<CommentResponse> writeComment(@PathVariable("insightId") Long insightId, @AuthenticationPrincipal UserDetails userDetails, @RequestBody Create request) {
+        // 임시 로직
+        if (userDetails == null) {
+            userDetails = new User("1", "temp", Collections.emptyList());
+        }
+        return ResponseEntity.ok().body(commentService.createComment(insightId, Long.valueOf(userDetails.getUsername()), request));
+    }
 
 }
 

--- a/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
@@ -1,11 +1,13 @@
 package zoo.insightnote.domain.comment.controller;
 
 import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,12 +25,19 @@ public class CommentControllerImpl implements CommentController {
     private final CommentService commentService;
 
     @PostMapping("/{insightId}/comments")
-    public ResponseEntity<CommentResponse> writeComment(@PathVariable("insightId") Long insightId, @AuthenticationPrincipal UserDetails userDetails, @RequestBody Create request) {
-        // 임시 로직
+    public ResponseEntity<CommentResponse> writeComment(@PathVariable("insightId") Long insightId,
+                                                        @AuthenticationPrincipal UserDetails userDetails,
+                                                        @RequestBody Create request) {
         if (userDetails == null) {
             userDetails = new User("1", "temp", Collections.emptyList());
         }
-        return ResponseEntity.ok().body(commentService.createComment(insightId, Long.valueOf(userDetails.getUsername()), request));
+        return ResponseEntity.ok()
+                .body(commentService.createComment(insightId, Long.valueOf(userDetails.getUsername()), request));
+    }
+
+    @GetMapping("/{insightId}/comments")
+    public ResponseEntity<List<CommentResponse>> listComments(@PathVariable("insightId") Long insightId) {
+        return ResponseEntity.ok().body(commentService.findCommentsByInsightId(insightId));
     }
 
 }

--- a/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
@@ -10,9 +10,11 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import zoo.insightnote.domain.comment.dto.CommentRequest;
 import zoo.insightnote.domain.comment.dto.CommentRequest.Create;
 import zoo.insightnote.domain.comment.dto.CommentResponse;
 import zoo.insightnote.domain.comment.service.CommentService;
@@ -25,19 +27,35 @@ public class CommentControllerImpl implements CommentController {
     private final CommentService commentService;
 
     @PostMapping("/{insightId}/comments")
-    public ResponseEntity<CommentResponse> writeComment(@PathVariable("insightId") Long insightId,
+    public ResponseEntity<CommentResponse> writeComment(@PathVariable Long insightId,
                                                         @AuthenticationPrincipal UserDetails userDetails,
                                                         @RequestBody Create request) {
-        if (userDetails == null) {
-            userDetails = new User("1", "temp", Collections.emptyList());
-        }
-        return ResponseEntity.ok()
-                .body(commentService.createComment(insightId, Long.valueOf(userDetails.getUsername()), request));
+        userDetails = validateUser(userDetails);
+        CommentResponse response = commentService.createComment(insightId, Long.valueOf(userDetails.getUsername()), request);
+        return ResponseEntity.ok().body(response);
     }
 
     @GetMapping("/{insightId}/comments")
-    public ResponseEntity<List<CommentResponse>> listComments(@PathVariable("insightId") Long insightId) {
+    public ResponseEntity<List<CommentResponse>> listComments(@PathVariable Long insightId) {
         return ResponseEntity.ok().body(commentService.findCommentsByInsightId(insightId));
+    }
+
+    @PutMapping("/{insightId}/comments/{commentId}")
+    public ResponseEntity<CommentResponse> updateComment(@PathVariable Long insightId,
+                                                         @PathVariable Long commentId,
+                                                         @AuthenticationPrincipal UserDetails userDetails,
+                                                         @RequestBody CommentRequest.Update request) {
+        userDetails = validateUser(userDetails);
+        CommentResponse response = commentService.updateComment(insightId, Long.valueOf(userDetails.getUsername()), commentId, request);
+        return ResponseEntity.ok().body(response);
+    }
+
+    // 임시 로직
+    private UserDetails validateUser(UserDetails userDetails) {
+        if (userDetails != null) {
+            return userDetails;
+        }
+        return new User("001", "password", Collections.emptyList());
     }
 
 }

--- a/src/main/java/zoo/insightnote/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/zoo/insightnote/domain/comment/dto/CommentRequest.java
@@ -9,4 +9,11 @@ public interface CommentRequest {
             String content
     ) implements CommentRequest {
     }
+
+    record Update(
+            @Schema(description = "댓글 내용", example = "작성하신 노트에 잘못된 부분이 있는것 같습니다!")
+            String content
+    ) implements CommentRequest {
+
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/zoo/insightnote/domain/comment/dto/CommentRequest.java
@@ -1,0 +1,12 @@
+package zoo.insightnote.domain.comment.dto;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public interface CommentRequest {
+    record Create(
+            @Schema(description = "댓글 내용", example = "작성하신 노트 잘보았습니다!")
+            String content
+    ) implements CommentRequest {
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/zoo/insightnote/domain/comment/dto/CommentResponse.java
@@ -3,6 +3,11 @@ package zoo.insightnote.domain.comment.dto;
 import java.time.LocalDateTime;
 
 public interface CommentResponse {
+
+    record Delete(Long commentId) implements CommentResponse{
+
+    }
+
     record Default(Long commentId, String content, LocalDateTime createAt, String author) implements CommentResponse{
 
     }

--- a/src/main/java/zoo/insightnote/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/zoo/insightnote/domain/comment/dto/CommentResponse.java
@@ -3,7 +3,7 @@ package zoo.insightnote.domain.comment.dto;
 import java.time.LocalDateTime;
 
 public interface CommentResponse {
-    record Default(Long id, String content, LocalDateTime createAt, String author) implements CommentResponse{
+    record Default(Long commentId, String content, LocalDateTime createAt, String author) implements CommentResponse{
 
     }
 }

--- a/src/main/java/zoo/insightnote/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/zoo/insightnote/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,9 @@
+package zoo.insightnote.domain.comment.dto;
+
+import java.time.LocalDateTime;
+
+public interface CommentResponse {
+    record Default(Long id, String content, LocalDateTime createAt, String author) implements CommentResponse{
+
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/comment/entity/Comment.java
+++ b/src/main/java/zoo/insightnote/domain/comment/entity/Comment.java
@@ -39,5 +39,11 @@ public class Comment extends BaseTimeEntity {
 
     private String content;
 
+    public void update(String content) {
+        if (content != null) {
+            this.content = content;
+        }
+    }
+
 }
 

--- a/src/main/java/zoo/insightnote/domain/comment/entity/Comment.java
+++ b/src/main/java/zoo/insightnote/domain/comment/entity/Comment.java
@@ -8,12 +8,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import zoo.insightnote.domain.insight.entity.Insight;
 import zoo.insightnote.domain.user.entity.User;
 import zoo.insightnote.global.entity.BaseTimeEntity;
 
 @Entity
+@Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseTimeEntity {
 
@@ -21,14 +27,17 @@ public class Comment extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    //TODO : user Entity 개발 완료시 nullable = false로 수정
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = true)
     private User user;
 
+    //TODO : insight Entity 개발 완료시 nullable = false로 수정
     @ManyToOne
-    @JoinColumn(name = "insight_id", nullable = false)
+    @JoinColumn(name = "insight_id", nullable = true)
     private Insight insight;
 
     private String content;
 
 }
+

--- a/src/main/java/zoo/insightnote/domain/comment/entity/Comment.java
+++ b/src/main/java/zoo/insightnote/domain/comment/entity/Comment.java
@@ -33,7 +33,7 @@ public class Comment extends BaseTimeEntity {
     private User user;
 
     //TODO : insight Entity 개발 완료시 nullable = false로 수정
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "insight_id", nullable = true)
     private Insight insight;
 

--- a/src/main/java/zoo/insightnote/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/zoo/insightnote/domain/comment/mapper/CommentMapper.java
@@ -1,0 +1,28 @@
+package zoo.insightnote.domain.comment.mapper;
+
+import zoo.insightnote.domain.comment.dto.CommentRequest;
+import zoo.insightnote.domain.comment.dto.CommentResponse;
+import zoo.insightnote.domain.comment.entity.Comment;
+import zoo.insightnote.domain.insight.entity.Insight;
+import zoo.insightnote.domain.user.entity.User;
+
+public class CommentMapper {
+
+    public static Comment toEntity(Insight insight, User user, CommentRequest.Create request) {
+        return Comment.builder()
+                .insight(insight)
+                .user(user)
+                .content(request.content())
+                .build();
+    }
+
+    public static CommentResponse toResponse(Comment comment) {
+        return new CommentResponse.Default(
+                comment.getId(),
+                comment.getContent(),
+                comment.getCreateAt(),
+                comment.getUser() == null ? "Anonymous" : "user"
+        );
+    }
+
+}

--- a/src/main/java/zoo/insightnote/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/zoo/insightnote/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,11 @@
 package zoo.insightnote.domain.comment.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import zoo.insightnote.domain.comment.entity.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query("SELECT c FROM Comment c WHERE c.insight.id = :insightId")
+    List<Comment> findAllByInsightId(Long insightId);
 }

--- a/src/main/java/zoo/insightnote/domain/comment/service/CommentService.java
+++ b/src/main/java/zoo/insightnote/domain/comment/service/CommentService.java
@@ -1,7 +1,37 @@
 package zoo.insightnote.domain.comment.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import zoo.insightnote.domain.comment.dto.CommentRequest;
+import zoo.insightnote.domain.comment.dto.CommentResponse;
+import zoo.insightnote.domain.comment.entity.Comment;
+import zoo.insightnote.domain.comment.mapper.CommentMapper;
+import zoo.insightnote.domain.comment.repository.CommentRepository;
+import zoo.insightnote.domain.insight.entity.Insight;
+import zoo.insightnote.domain.insight.repository.InsightRepository;
+import zoo.insightnote.domain.user.entity.User;
+import zoo.insightnote.domain.user.repository.UserRepository;
+import zoo.insightnote.global.exception.CustomException;
 
 @Service
+@RequiredArgsConstructor
 public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final InsightRepository insightRepository;
+
+    public CommentResponse createComment(Long insightId, Long userId, CommentRequest.Create request) {
+
+        Insight insight = insightRepository.findById(insightId)
+                .orElseThrow(() -> new CustomException(null, "인사이트 노트를 찾을 수 없음"));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(null, "사용자를 찾을 수 없음"));
+
+        Comment comment = CommentMapper.toEntity(insight, user, request);
+        comment = commentRepository.save(comment);
+        return CommentMapper.toResponse(comment);
+    }
+
 }

--- a/src/main/java/zoo/insightnote/domain/comment/service/CommentService.java
+++ b/src/main/java/zoo/insightnote/domain/comment/service/CommentService.java
@@ -1,5 +1,7 @@
 package zoo.insightnote.domain.comment.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import zoo.insightnote.domain.comment.dto.CommentRequest;
@@ -22,7 +24,6 @@ public class CommentService {
     private final InsightRepository insightRepository;
 
     public CommentResponse createComment(Long insightId, Long userId, CommentRequest.Create request) {
-
         Insight insight = insightRepository.findById(insightId)
                 .orElseThrow(() -> new CustomException(null, "인사이트 노트를 찾을 수 없음"));
 
@@ -32,6 +33,17 @@ public class CommentService {
         Comment comment = CommentMapper.toEntity(insight, user, request);
         comment = commentRepository.save(comment);
         return CommentMapper.toResponse(comment);
+    }
+
+    public List<CommentResponse> findCommentsByInsightId(Long insightId) {
+        List<Comment> comments = commentRepository.findAllByInsightId(insightId);
+
+        List<CommentResponse> responses = new ArrayList<>();
+        for (Comment comment : comments) {
+            responses.add(CommentMapper.toResponse(comment));
+        }
+
+        return responses;
     }
 
 }

--- a/src/main/java/zoo/insightnote/domain/comment/service/CommentService.java
+++ b/src/main/java/zoo/insightnote/domain/comment/service/CommentService.java
@@ -34,7 +34,9 @@ public class CommentService {
                 .orElseThrow(() -> new CustomException(null, "사용자를 찾을 수 없음"));
 
         Comment comment = CommentMapper.toEntity(insight, user, request);
+
         comment = commentRepository.save(comment);
+
         return CommentMapper.toResponse(comment);
     }
 
@@ -50,17 +52,27 @@ public class CommentService {
         return responses;
     }
 
-    // 댓글을 작성할 때 인사이트 노트를 찾을까 말까?
     @Transactional
     public CommentResponse updateComment(Long insightId, Long userId, Long commentId, CommentRequest.Update request) {
 
         Comment comment = findCommentById(commentId);
 
-        validateAuthorCheck(comment, userId);
+        validateAuthor(comment, userId);
 
         comment.update(request.content());
 
         return CommentMapper.toResponse(comment);
+    }
+
+    public CommentResponse deleteComment(Long insightId, Long userId, Long commentId) {
+
+        Comment comment = findCommentById(commentId);
+
+        validateAuthor(comment, userId);
+
+        commentRepository.deleteById(commentId);
+
+        return new CommentResponse.Delete(commentId);
     }
 
     private Comment findCommentById(Long commentId) {
@@ -68,7 +80,7 @@ public class CommentService {
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
     }
 
-    private void validateAuthorCheck(Comment comment, Long userId) {
+    private void validateAuthor(Comment comment, Long userId) {
         if (!comment.getUser().getId().equals(userId)) {
             throw new CustomException(ErrorCode.UNAUTHORIZED_COMMENT_MODIFICATION);
         }

--- a/src/main/java/zoo/insightnote/domain/insight/entity/Insight.java
+++ b/src/main/java/zoo/insightnote/domain/insight/entity/Insight.java
@@ -9,11 +9,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import zoo.insightnote.domain.session.entity.Session;
 import zoo.insightnote.global.entity.BaseTimeEntity;
 
 @Entity
+@Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Insight extends BaseTimeEntity {
 

--- a/src/main/java/zoo/insightnote/domain/user/entity/User.java
+++ b/src/main/java/zoo/insightnote/domain/user/entity/User.java
@@ -6,8 +6,16 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class User {
 
     @Id

--- a/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package zoo.insightnote.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable);
+        return http.build();
+    }
+}

--- a/src/main/java/zoo/insightnote/global/entity/BaseTimeEntity.java
+++ b/src/main/java/zoo/insightnote/global/entity/BaseTimeEntity.java
@@ -5,6 +5,8 @@ import jakarta.persistence.EntityListeners;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
@@ -12,7 +14,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
+
+    @CreatedDate
     private LocalDateTime createAt;
+
+    @LastModifiedDate
     private LocalDateTime updatedAt;
+
     private LocalDateTime deletedAt;
 }

--- a/src/main/java/zoo/insightnote/global/exception/ErrorCode.java
+++ b/src/main/java/zoo/insightnote/global/exception/ErrorCode.java
@@ -5,7 +5,11 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-    ;
+
+    //Comment ErrorCode
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    UNAUTHORIZED_COMMENT_MODIFICATION(HttpStatus.BAD_REQUEST, "작성자만 댓글을 수정할 수 있습니다.");
+
     private final HttpStatus errorCode;
     private final String errorMessage;
 
@@ -13,4 +17,5 @@ public enum ErrorCode {
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
     }
+
 }

--- a/src/test/java/zoo/insightnote/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/zoo/insightnote/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,116 @@
+package zoo.insightnote.domain.comment.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import zoo.insightnote.domain.comment.dto.CommentRequest;
+import zoo.insightnote.domain.comment.dto.CommentRequest.Create;
+import zoo.insightnote.domain.comment.dto.CommentResponse;
+import zoo.insightnote.domain.comment.entity.Comment;
+import zoo.insightnote.domain.comment.repository.CommentRepository;
+import zoo.insightnote.domain.insight.entity.Insight;
+import zoo.insightnote.domain.insight.repository.InsightRepository;
+import zoo.insightnote.domain.user.entity.User;
+import zoo.insightnote.domain.user.repository.UserRepository;
+import zoo.insightnote.global.exception.CustomException;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @Mock
+    CommentRepository commentRepository;
+
+    @Mock
+    InsightRepository insightRepository;
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    CommentService commentService;
+
+    Insight insight;
+
+    User author;
+
+    Comment comment;
+
+    @BeforeEach
+    void beforeEach() {
+        insight = Insight
+                .builder()
+                .id(1L)
+                .build();
+
+        author = User.builder()
+                .id(1L)
+                .build();
+
+        comment = Comment.builder()
+                .id(1L)
+                .insight(insight)
+                .user(author)
+                .content("작성하신 노트 잘보았습니다!")
+                .build();
+    }
+
+    @Test
+    @DisplayName("테스트 성공 : 유효한 요청인 경우 인사이트 노트에 댓글을 작성할 수 있다.")
+    void 사용자는_댓글을_작성할_수_있다() {
+        // given
+        CommentRequest.Create request = new Create("작성하신 노트 잘보았습니다!");
+
+        // when
+        when(insightRepository.findById(any(Long.class))).thenReturn(Optional.of(insight));
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(author));
+        when(commentRepository.save(any(Comment.class))).thenReturn(comment);
+
+        CommentResponse.Default response = (CommentResponse.Default) commentService.createComment(insight.getId(), author.getId(), request);
+
+        // then
+        Assertions.assertThat(response.id()).isEqualTo(1L);
+        Assertions.assertThat(response.content()).isEqualTo("작성하신 노트 잘보았습니다!");
+    }
+
+    @Test
+    @DisplayName("테스트 실패 : 존재하지 않은 인사이트 노트에 댓글을 작성할 수 없다.")
+    void 댓글_작성_실패_존재하지_않은_인사이트_노트() {
+        // given
+        CommentRequest.Create request = new Create("작성하신 노트 잘보았습니다!");
+
+        // when
+        when(insightRepository.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        // then
+        Assertions.assertThatThrownBy(() -> commentService.createComment(insight.getId(), author.getId(), request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("인사이트 노트를 찾을 수 없음");
+    }
+
+    @Test
+    @DisplayName("테스트 실패 : 로그인되지 않은 사용자는 댓글을 작성할 수 없다.")
+    void 댓글_작성_실패_비회원() {
+        // given
+        CommentRequest.Create request = new Create("작성하신 노트 잘보았습니다!");
+
+        // when
+        when(insightRepository.findById(any(Long.class))).thenReturn(Optional.of(insight));
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        // then
+        Assertions.assertThatThrownBy(() -> commentService.createComment(insight.getId(), author.getId(), request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("사용자를 찾을 수 없음");
+    }
+
+
+}

--- a/src/test/java/zoo/insightnote/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/zoo/insightnote/domain/comment/service/CommentServiceTest.java
@@ -78,7 +78,8 @@ class CommentServiceTest {
         when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(author));
         when(commentRepository.save(any(Comment.class))).thenReturn(comment);
 
-        CommentResponse.Default response = (CommentResponse.Default) commentService.createComment(insight.getId(), author.getId(), request);
+        CommentResponse.Default response = (CommentResponse.Default) commentService.createComment(insight.getId(),
+                author.getId(), request);
 
         // then
         assertThat(response.commentId()).isEqualTo(1L);
@@ -132,6 +133,40 @@ class CommentServiceTest {
 
         // then
         assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("테스트 성공 : 본인이 작성한 댓글은 수정할 수 있다.")
+    void 댓글_수정_성공() {
+        //given
+        String updatedContent = "수정된 댓글 내용";
+        CommentRequest.Update request = new CommentRequest.Update(updatedContent);
+
+        when(commentRepository.findById(any())).thenReturn(Optional.of(comment));
+
+        //when
+        CommentResponse.Default response = (CommentResponse.Default) commentService.updateComment(insight.getId(),
+                author.getId(), comment.getId(), request);
+
+        //then
+        Assertions.assertThat(response.content()).isEqualTo(updatedContent);
+    }
+
+    @Test
+    @DisplayName("테스트 성공 : 본인이 작성한 댓글은 수정할 수 있다.")
+    void 댓글_수정_실패() {
+        //given
+        Long anotherAuthorId = 2L;
+        String updatedContent = "수정된 댓글 내용";
+        CommentRequest.Update request = new CommentRequest.Update(updatedContent);
+
+        when(commentRepository.findById(any())).thenReturn(Optional.of(comment));
+
+        //when && then
+        Assertions.assertThatThrownBy(() -> commentService.updateComment(insight.getId(), anotherAuthorId, comment.getId(), request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("작성자만 댓글을 수정할 수 있습니다.");
+
     }
 
 

--- a/src/test/java/zoo/insightnote/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/zoo/insightnote/domain/comment/service/CommentServiceTest.java
@@ -1,8 +1,12 @@
 package zoo.insightnote.domain.comment.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,8 +81,8 @@ class CommentServiceTest {
         CommentResponse.Default response = (CommentResponse.Default) commentService.createComment(insight.getId(), author.getId(), request);
 
         // then
-        Assertions.assertThat(response.id()).isEqualTo(1L);
-        Assertions.assertThat(response.content()).isEqualTo("작성하신 노트 잘보았습니다!");
+        assertThat(response.commentId()).isEqualTo(1L);
+        assertThat(response.content()).isEqualTo("작성하신 노트 잘보았습니다!");
     }
 
     @Test
@@ -110,6 +114,24 @@ class CommentServiceTest {
         Assertions.assertThatThrownBy(() -> commentService.createComment(insight.getId(), author.getId(), request))
                 .isInstanceOf(CustomException.class)
                 .hasMessage("사용자를 찾을 수 없음");
+    }
+
+    @Test
+    @DisplayName("테스트 성공: 인사이트 노트의 모든 댓글을 조회한다.")
+    void 인사이트_노트_모든_댓글_조회() {
+        // given
+        List<Comment> comments = Arrays.asList(
+                new Comment(1L, author, insight, "댓글1"),
+                new Comment(2L, author, insight, "댓글2")
+        );
+
+        when(commentRepository.findAllByInsightId(eq(1L))).thenReturn(comments);
+
+        // when
+        List<CommentResponse> result = commentService.findCommentsByInsightId(1L);
+
+        // then
+        assertThat(result).hasSize(2);
     }
 
 

--- a/src/test/java/zoo/insightnote/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/zoo/insightnote/domain/comment/service/CommentServiceTest.java
@@ -153,7 +153,7 @@ class CommentServiceTest {
     }
 
     @Test
-    @DisplayName("테스트 성공 : 본인이 작성한 댓글은 수정할 수 있다.")
+    @DisplayName("테스트 실패 : 본인이 작성하지 않은 댓글은 수정할 수 없다.")
     void 댓글_수정_실패() {
         //given
         Long anotherAuthorId = 2L;


### PR DESCRIPTION
## Summary

>- 관련 있는 Issue를 태그해주세요.
closes #1 
인사이트 노트에 댓글을 작성, 조회, 수정, 삭제할 수 있는 기능을 개발하였습니다.

## Tasks

- 댓글 작성
- 댓글 조회
- 댓글 수정
- 댓글 삭제

## To Reviewer

**질문 1: 사용자 인증 방식**

현재 `CommentController` 클래스에서 `@AuthenticationPrincipal` 어노테이션을 사용하여 인증 여부를 체크하고, `null`인 경우 임시 ID를 부여하는 방식으로 구현하고 있습니다. 이후 JWT 개발이 완료되면 `userDetails.getUserName()` 대신 `userDetails.getId()`로 ID 값을 가져오는 방식으로 사용자 인증을 처리할 예정인데. 영광님께서는 사용자 인증을 어떻게 구현할 계획이신지 궁금합니다.


**질문 2: 인사이트 노트 존재 여부 확인**

`CommentService` 클래스의 `update`와 `delete` 메서드에서 `insightId`를 파라미터로 받고 있습니다. 댓글을 수정하거나 삭제하기 전에 인사이트 노트가 존재하는지 확인하는 로직을 추가하는 것이 적합한지 고민입니다. 만약 인사이트 노트가 존재하지 않으면 수정이나 삭제가 불가능하다는 점은 이해하고 있습니다. 이 경우, 인사이트 노트의 존재 여부를 조회 쿼리로 검증하는 방식이 나을지, 아니면 댓글을 고아 객체로 처리하여 인사이트가 삭제될 때 댓글도 함께 삭제되도록 처리하는 방식이 나을지에 대해 의견을 듣고 싶습니다.

추가적으로 코드에 잘못된 로직이나 개선사항이 있는 경우 지적해주시면 감사하겠습니다👍

## Screenshot
![image](https://github.com/user-attachments/assets/b7bdc7cc-acbe-4225-8abc-c2646a07ef28)
