### PR TITLE
[#2] 컨벤션 CRUD + S3 presigned URL 적용 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //aws-s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -33,6 +33,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 
     //aws-s3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/src/main/java/zoo/insightnote/domain/event/controller/EventController.java
+++ b/src/main/java/zoo/insightnote/domain/event/controller/EventController.java
@@ -1,4 +1,37 @@
 package zoo.insightnote.domain.event.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import zoo.insightnote.domain.event.dto.req.EventRequestDto;
+import zoo.insightnote.domain.event.dto.req.EventUpdateRequestDto;
+import zoo.insightnote.domain.event.dto.res.EventResponseDto;
+
+@Tag(name = "EVENT", description = "이벤트 관련 API")  // Swagger 태그
+@RequestMapping("/api/v1/events")
 public interface EventController {
+
+    @Operation(summary = "이벤트 생성 API", description = "새로운 이벤트를 생성합니다.")
+    @ApiResponse(responseCode = "200", description = "이벤트 생성 성공", content = @Content(schema = @Schema(implementation = EventResponseDto.class)))
+    @PostMapping
+    ResponseEntity<EventResponseDto> createEvent(@RequestBody EventRequestDto request);
+
+    @Operation(summary = "이벤트 조회 API", description = "특정 ID의 이벤트를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "이벤트 조회 성공", content = @Content(schema = @Schema(implementation = EventResponseDto.class)))
+    @GetMapping("/{id}")
+    ResponseEntity<EventResponseDto> getEventById(@PathVariable Long id);
+
+    @Operation(summary = "이벤트 수정 API", description = "이벤트 정보를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "이벤트 수정 성공", content = @Content(schema = @Schema(implementation = EventResponseDto.class)))
+    @PutMapping("/{id}")
+    ResponseEntity<EventResponseDto> updateEvent(@PathVariable Long id, @RequestBody EventUpdateRequestDto request);
+
+    @Operation(summary = "이벤트 삭제 API", description = "이벤트를 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "이벤트 삭제 성공")
+    @DeleteMapping("/{id}")
+    ResponseEntity<Void> deleteEvent(@PathVariable Long id);
 }

--- a/src/main/java/zoo/insightnote/domain/event/controller/EventControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/event/controller/EventControllerImpl.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import zoo.insightnote.domain.event.dto.req.EventRequestDto;
+import zoo.insightnote.domain.event.dto.req.EventUpdateRequestDto;
+import zoo.insightnote.domain.event.dto.res.EventResponseDto;
 import zoo.insightnote.domain.event.entity.Event;
 import zoo.insightnote.domain.event.service.EventService;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,14 +19,34 @@ public class EventControllerImpl {
     @PostMapping
     public ResponseEntity<Event> createEvent(@RequestBody EventRequestDto request) {
         Event event = Event.builder()
-                .name(request.getName())
-                .description(request.getDescription())
-                .location(request.getLocation())
-                .startTime(request.getStartTime())
-                .endTime(request.getEndTime())
+                .name(request.name())
+                .description(request.description())
+                .location(request.location())
+                .startTime(request.startTime())
+                .endTime(request.endTime())
                 .build();
 
-        Event savedEvent = eventService.createEventWithImages(event, request.getImageUrls());
+        Event savedEvent = eventService.createEventWithImages(event, request.imageUrls());
         return ResponseEntity.ok(savedEvent);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<EventResponseDto> getEventById(@PathVariable Long id) {
+        EventResponseDto event = eventService.getEventById(id);
+        return ResponseEntity.ok(event);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<EventResponseDto> updateEvent(
+            @PathVariable Long id,
+            @RequestBody EventUpdateRequestDto request) {
+        EventResponseDto updatedEvent = eventService.updateEvent(id, request);
+        return ResponseEntity.ok(updatedEvent);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteEvent(@PathVariable Long id) {
+        eventService.deleteEvent(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/zoo/insightnote/domain/event/controller/EventControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/event/controller/EventControllerImpl.java
@@ -1,7 +1,30 @@
 package zoo.insightnote.domain.event.controller;
 
-import org.springframework.stereotype.Controller;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import zoo.insightnote.domain.event.dto.req.EventRequestDto;
+import zoo.insightnote.domain.event.entity.Event;
+import zoo.insightnote.domain.event.service.EventService;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-public class EventControllerImpl implements EventController{
+@RestController
+@RequestMapping("/api/v1/events")
+@RequiredArgsConstructor
+public class EventControllerImpl {
+    private final EventService eventService;
+
+    @PostMapping
+    public ResponseEntity<Event> createEvent(@RequestBody EventRequestDto request) {
+        Event event = Event.builder()
+                .name(request.getName())
+                .description(request.getDescription())
+                .location(request.getLocation())
+                .startTime(request.getStartTime())
+                .endTime(request.getEndTime())
+                .build();
+
+        Event savedEvent = eventService.createEventWithImages(event, request.getImageUrls());
+        return ResponseEntity.ok(savedEvent);
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/event/controller/EventControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/event/controller/EventControllerImpl.java
@@ -13,29 +13,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/events")
 @RequiredArgsConstructor
-public class EventControllerImpl {
+public class EventControllerImpl implements EventController {
     private final EventService eventService;
 
+    @Override
     @PostMapping
-    public ResponseEntity<Event> createEvent(@RequestBody EventRequestDto request) {
-        Event event = Event.builder()
-                .name(request.name())
-                .description(request.description())
-                .location(request.location())
-                .startTime(request.startTime())
-                .endTime(request.endTime())
-                .build();
-
-        Event savedEvent = eventService.createEventWithImages(event, request.imageUrls());
+    public ResponseEntity<EventResponseDto> createEvent(@RequestBody EventRequestDto request) {
+        EventResponseDto savedEvent = eventService.createEvent(request);
         return ResponseEntity.ok(savedEvent);
     }
 
+    @Override
     @GetMapping("/{id}")
     public ResponseEntity<EventResponseDto> getEventById(@PathVariable Long id) {
         EventResponseDto event = eventService.getEventById(id);
         return ResponseEntity.ok(event);
     }
 
+    @Override
     @PutMapping("/{id}")
     public ResponseEntity<EventResponseDto> updateEvent(
             @PathVariable Long id,
@@ -44,6 +39,7 @@ public class EventControllerImpl {
         return ResponseEntity.ok(updatedEvent);
     }
 
+    @Override
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteEvent(@PathVariable Long id) {
         eventService.deleteEvent(id);

--- a/src/main/java/zoo/insightnote/domain/event/dto/req/EventRequestDto.java
+++ b/src/main/java/zoo/insightnote/domain/event/dto/req/EventRequestDto.java
@@ -1,0 +1,17 @@
+package zoo.insightnote.domain.event.dto.req;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+public class EventRequestDto {
+    private String name;
+    private String description;
+    private String location;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private List<String> imageUrls;
+}

--- a/src/main/java/zoo/insightnote/domain/event/dto/req/EventUpdateRequestDto.java
+++ b/src/main/java/zoo/insightnote/domain/event/dto/req/EventUpdateRequestDto.java
@@ -1,13 +1,11 @@
 package zoo.insightnote.domain.event.dto.req;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
-public record EventRequestDto(
+public record EventUpdateRequestDto(
         String name,
         String description,
         String location,
         LocalDateTime startTime,
-        LocalDateTime endTime,
-        List<String> imageUrls
+        LocalDateTime endTime
 ) {}

--- a/src/main/java/zoo/insightnote/domain/event/dto/req/EventUpdateRequestDto.java
+++ b/src/main/java/zoo/insightnote/domain/event/dto/req/EventUpdateRequestDto.java
@@ -1,11 +1,13 @@
 package zoo.insightnote.domain.event.dto.req;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record EventUpdateRequestDto(
         String name,
         String description,
         String location,
         LocalDateTime startTime,
-        LocalDateTime endTime
+        LocalDateTime endTime,
+        List<String> imageUrls
 ) {}

--- a/src/main/java/zoo/insightnote/domain/event/dto/res/EventResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/event/dto/res/EventResponseDto.java
@@ -1,0 +1,24 @@
+package zoo.insightnote.domain.event.dto.res;
+
+import zoo.insightnote.domain.event.entity.Event;
+import java.time.LocalDateTime;
+
+public record EventResponseDto(
+        Long id,
+        String name,
+        String description,
+        String location,
+        LocalDateTime startTime,
+        LocalDateTime endTime
+) {
+    public static EventResponseDto fromEntity(Event event) {
+        return new EventResponseDto(
+                event.getId(),
+                event.getName(),
+                event.getDescription(),
+                event.getLocation(),
+                event.getStartTime(),
+                event.getEndTime()
+        );
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/event/entity/Event.java
+++ b/src/main/java/zoo/insightnote/domain/event/entity/Event.java
@@ -5,11 +5,16 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Event {
     @Id
@@ -19,6 +24,15 @@ public class Event {
     private String name;
     private String description;
     private String location;
-    private LocalTime startTime;
-    private LocalTime endTime;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    @Builder
+    public Event(String name, String description, String location, LocalDateTime startTime, LocalDateTime endTime) {
+        this.name = name;
+        this.description = description;
+        this.location = location;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/event/entity/Event.java
+++ b/src/main/java/zoo/insightnote/domain/event/entity/Event.java
@@ -1,13 +1,11 @@
 package zoo.insightnote.domain.event.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,5 +32,17 @@ public class Event {
         this.location = location;
         this.startTime = startTime;
         this.endTime = endTime;
+    }
+
+    public void update(String name, String description, String location, LocalDateTime startTime, LocalDateTime endTime) {
+        if (isChanged(this.name, name)) this.name = name;
+        if (isChanged(this.description, description)) this.description = description;
+        if (isChanged(this.location, location)) this.location = location;
+        if (isChanged(this.startTime, startTime)) this.startTime = startTime;
+        if (isChanged(this.endTime, endTime)) this.endTime = endTime;
+    }
+
+    private boolean isChanged(Object currentValue, Object newValue) {
+        return newValue != null && !newValue.equals(currentValue);
     }
 }

--- a/src/main/java/zoo/insightnote/domain/event/service/EventService.java
+++ b/src/main/java/zoo/insightnote/domain/event/service/EventService.java
@@ -3,11 +3,15 @@ package zoo.insightnote.domain.event.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import zoo.insightnote.domain.event.dto.req.EventUpdateRequestDto;
+import zoo.insightnote.domain.event.dto.res.EventResponseDto;
 import zoo.insightnote.domain.event.entity.Event;
 import zoo.insightnote.domain.event.repository.EventRepository;
 import zoo.insightnote.domain.image.entity.EntityType;
 import zoo.insightnote.domain.image.entity.Image;
 import zoo.insightnote.domain.image.repository.ImageRepository;
+import zoo.insightnote.global.exception.CustomException;
+import zoo.insightnote.global.exception.ErrorCode;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,15 +24,45 @@ public class EventService {
 
     @Transactional
     public Event createEventWithImages(Event event, List<String> imageUrls) {
-        // 행사 저장
+
         Event savedEvent = eventRepository.save(event);
 
-        // 이미지 저장
+        // 이미지 저장(클라이언트에서 전달)
         List<Image> images = imageUrls.stream()
                 .map(url -> Image.of("event-image", url, savedEvent.getId(), EntityType.EVENT))
                 .collect(Collectors.toList());
 
         imageRepository.saveAll(images);
         return savedEvent;
+    }
+
+    public EventResponseDto getEventById(Long id) {
+        Event event = eventRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+        return EventResponseDto.fromEntity(event);
+    }
+
+    @Transactional
+    public EventResponseDto updateEvent(Long id, EventUpdateRequestDto request) {
+        Event event = eventRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+
+        event.update(
+                request.name(),
+                request.description(),
+                request.location(),
+                request.startTime(),
+                request.endTime()
+        );
+
+        return EventResponseDto.fromEntity(event);
+    }
+
+    @Transactional
+    public void deleteEvent(Long id) {
+        Event event = eventRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+
+        eventRepository.delete(event);
     }
 }

--- a/src/main/java/zoo/insightnote/domain/event/service/EventService.java
+++ b/src/main/java/zoo/insightnote/domain/event/service/EventService.java
@@ -1,7 +1,34 @@
 package zoo.insightnote.domain.event.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import zoo.insightnote.domain.event.entity.Event;
+import zoo.insightnote.domain.event.repository.EventRepository;
+import zoo.insightnote.domain.image.entity.EntityType;
+import zoo.insightnote.domain.image.entity.Image;
+import zoo.insightnote.domain.image.repository.ImageRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class EventService {
+    private final EventRepository eventRepository;
+    private final ImageRepository imageRepository;
+
+    @Transactional
+    public Event createEventWithImages(Event event, List<String> imageUrls) {
+        // 행사 저장
+        Event savedEvent = eventRepository.save(event);
+
+        // 이미지 저장
+        List<Image> images = imageUrls.stream()
+                .map(url -> Image.of("event-image", url, savedEvent.getId(), EntityType.EVENT))
+                .collect(Collectors.toList());
+
+        imageRepository.saveAll(images);
+        return savedEvent;
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/event/service/EventService.java
+++ b/src/main/java/zoo/insightnote/domain/event/service/EventService.java
@@ -98,6 +98,16 @@ public class EventService {
         Event event = eventRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
 
+        List<String> imageUrls = imageRepository.findByEntityIdAndEntityType(event.getId(), EntityType.EVENT)
+                .stream()
+                .map(Image::getFileUrl)
+                .collect(Collectors.toList());
+
+        if (!imageUrls.isEmpty()) {
+            s3Service.deleteImages(imageUrls);
+        }
+        imageRepository.deleteByEntityIdAndEntityType(event.getId(), EntityType.EVENT);
+
         eventRepository.delete(event);
     }
 }

--- a/src/main/java/zoo/insightnote/domain/image/entity/EntityType.java
+++ b/src/main/java/zoo/insightnote/domain/image/entity/EntityType.java
@@ -1,0 +1,5 @@
+package zoo.insightnote.domain.image.entity;
+
+public enum EntityType {
+    EVENT, SESSION, SPEAKER, INSIGHT
+}

--- a/src/main/java/zoo/insightnote/domain/image/entity/Image.java
+++ b/src/main/java/zoo/insightnote/domain/image/entity/Image.java
@@ -1,10 +1,11 @@
 package zoo.insightnote.domain.image.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import zoo.insightnote.global.entity.BaseTimeEntity;
 
 @Entity
-
+@Getter
 public class Image extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/zoo/insightnote/domain/image/entity/Image.java
+++ b/src/main/java/zoo/insightnote/domain/image/entity/Image.java
@@ -1,0 +1,23 @@
+package zoo.insightnote.domain.image.entity;
+
+import jakarta.persistence.*;
+import zoo.insightnote.global.entity.BaseTimeEntity;
+
+@Entity
+
+public class Image extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String fileName;
+
+    private String fileUrl;
+
+    private Long entityId;
+
+    @Enumerated(EnumType.STRING)
+    private EntityType entityType; // 이미지가 속한 도메인 (EVENT, SESSION, SPEAKER, INSIGHT)
+
+}

--- a/src/main/java/zoo/insightnote/domain/image/entity/Image.java
+++ b/src/main/java/zoo/insightnote/domain/image/entity/Image.java
@@ -20,4 +20,13 @@ public class Image extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private EntityType entityType; // 이미지가 속한 도메인 (EVENT, SESSION, SPEAKER, INSIGHT)
 
+
+    public static Image of(String fileName, String fileUrl, Long entityId, EntityType entityType) {
+        Image image = new Image();
+        image.fileName = fileName;
+        image.fileUrl = fileUrl;
+        image.entityId = entityId;
+        image.entityType = entityType;
+        return image;
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/image/repository/ImageRepository.java
+++ b/src/main/java/zoo/insightnote/domain/image/repository/ImageRepository.java
@@ -9,6 +9,8 @@ import java.util.List;
 public interface ImageRepository extends JpaRepository<Image, Long> {
     void deleteByFileUrlIn(List<String> fileUrls);
 
+    void deleteByEntityIdAndEntityType(Long entityId, EntityType entityType);
+
     List<Image> findByEntityIdAndEntityType(Long entityId, EntityType entityType);
 
 }

--- a/src/main/java/zoo/insightnote/domain/image/repository/ImageRepository.java
+++ b/src/main/java/zoo/insightnote/domain/image/repository/ImageRepository.java
@@ -1,7 +1,14 @@
 package zoo.insightnote.domain.image.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import zoo.insightnote.domain.image.entity.EntityType;
 import zoo.insightnote.domain.image.entity.Image;
 
+import java.util.List;
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
+    void deleteByFileUrlIn(List<String> fileUrls);
+
+    List<Image> findByEntityIdAndEntityType(Long entityId, EntityType entityType);
+
 }

--- a/src/main/java/zoo/insightnote/domain/image/repository/ImageRepository.java
+++ b/src/main/java/zoo/insightnote/domain/image/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package zoo.insightnote.domain.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import zoo.insightnote.domain.image.entity.Image;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/zoo/insightnote/domain/image/service/ImageService.java
+++ b/src/main/java/zoo/insightnote/domain/image/service/ImageService.java
@@ -1,0 +1,21 @@
+package zoo.insightnote.domain.image.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import zoo.insightnote.domain.image.entity.EntityType;
+import zoo.insightnote.domain.image.entity.Image;
+import zoo.insightnote.domain.image.repository.ImageRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final ImageRepository imageRepository;
+
+    @Transactional
+    public Image saveImage(String fileName, String fileUrl, EntityType entityType, Long entityId) {
+        Image image = Image.of(fileName, fileUrl, entityId, entityType);
+        return imageRepository.save(image);
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/s3/controller/S3Controller.java
+++ b/src/main/java/zoo/insightnote/domain/s3/controller/S3Controller.java
@@ -1,22 +1,32 @@
 package zoo.insightnote.domain.s3.controller;
 
-import lombok.RequiredArgsConstructor;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import zoo.insightnote.domain.image.entity.EntityType;
-import zoo.insightnote.domain.s3.service.S3Service;
 
 import java.util.List;
 
-@RestController
+@Tag(name = "S3", description = "S3 Presigned URL API")  // Swagger 태그 추가
 @RequestMapping("/s3")
-@RequiredArgsConstructor
-public class S3Controller {
-    private final S3Service s3Service;
+public interface S3Controller {
 
+    @Operation(summary = "Presigned URL 요청", description = """
+            - S3 Presigned URL을 생성하는 API입니다.
+            - 이 API로 받은 URL그대로 요청을 보내면 되고 요청을 날릴때 Body의 binary에 이미지 파일을 첨부하면 S3에 이미지를 직접 업로드할 수 있습니다.
+        """)
+    @ApiResponse(
+            responseCode = "200",
+            description = "Presigned URL 리스트 반환 성공",
+            content = @Content(schema = @Schema(implementation = String.class))
+    )
     @PostMapping("/presigned-urls")
-    public ResponseEntity<List<String>> getPresignedUrls(@RequestParam EntityType entityType, @RequestBody List<String> fileNames) {
-        List<String> urls = s3Service.getPresignedUrlsForImages(entityType, fileNames);
-        return ResponseEntity.ok(urls);
-    }
+    ResponseEntity<List<String>> getPresignedUrls(
+            @RequestParam EntityType entityType,
+            @RequestBody List<String> fileNames
+    );
 }

--- a/src/main/java/zoo/insightnote/domain/s3/controller/S3Controller.java
+++ b/src/main/java/zoo/insightnote/domain/s3/controller/S3Controller.java
@@ -1,0 +1,22 @@
+package zoo.insightnote.domain.s3.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import zoo.insightnote.domain.image.entity.EntityType;
+import zoo.insightnote.domain.s3.service.S3Service;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/s3")
+@RequiredArgsConstructor
+public class S3Controller {
+    private final S3Service s3Service;
+
+    @PostMapping("/presigned-urls")
+    public ResponseEntity<List<String>> getPresignedUrls(@RequestParam EntityType entityType, @RequestBody List<String> fileNames) {
+        List<String> urls = s3Service.getPresignedUrlsForImages(entityType, fileNames);
+        return ResponseEntity.ok(urls);
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/s3/controller/S3ControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/s3/controller/S3ControllerImpl.java
@@ -1,0 +1,23 @@
+package zoo.insightnote.domain.s3.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import zoo.insightnote.domain.image.entity.EntityType;
+import zoo.insightnote.domain.s3.service.S3Service;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/s3")
+@RequiredArgsConstructor
+public class S3ControllerImpl implements S3Controller  {
+    private final S3Service s3Service;
+
+    @Override
+    @PostMapping("/presigned-urls")
+    public ResponseEntity<List<String>> getPresignedUrls(@RequestParam EntityType entityType, @RequestBody List<String> fileNames) {
+        List<String> urls = s3Service.getPresignedUrlsForImages(entityType, fileNames);
+        return ResponseEntity.ok(urls);
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/s3/service/S3Service.java
+++ b/src/main/java/zoo/insightnote/domain/s3/service/S3Service.java
@@ -42,4 +42,15 @@ public class S3Service {
 
         return amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest);
     }
+
+    public void deleteImages(List<String> imageUrls) {
+        for (String imageUrl : imageUrls) {
+            String key = extractKeyFromUrl(imageUrl);
+            amazonS3Client.deleteObject(bucket, key);
+        }
+    }
+
+    private String extractKeyFromUrl(String imageUrl) {
+        return imageUrl.replace("https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/", "");
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/s3/service/S3Service.java
+++ b/src/main/java/zoo/insightnote/domain/s3/service/S3Service.java
@@ -1,0 +1,45 @@
+package zoo.insightnote.domain.s3.service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import zoo.insightnote.domain.image.entity.EntityType;
+import java.net.URL;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    private final AmazonS3 amazonS3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public List<String> getPresignedUrlsForImages(EntityType entityType, List<String> fileNames) {
+        return fileNames.stream()
+                .map(fileName -> createPresignedUrl(generateS3Key(entityType, fileName)).toExternalForm())
+                .collect(Collectors.toList());
+    }
+
+    private String generateS3Key(EntityType entityType, String fileName) {
+        return String.format("%s/%s-%s", entityType.name().toLowerCase(), UUID.randomUUID(), fileName);
+    }
+
+    private URL createPresignedUrl(String key) {
+        Date expiration = new Date();
+        expiration.setTime(expiration.getTime() + 1000 * 60 * 10); // 10분 유효
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, key)
+                        .withMethod(HttpMethod.PUT)
+                        .withExpiration(expiration);
+
+        return amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest);
+    }
+}

--- a/src/main/java/zoo/insightnote/global/config/S3Config.java
+++ b/src/main/java/zoo/insightnote/global/config/S3Config.java
@@ -1,0 +1,28 @@
+package zoo.insightnote.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${spring.cloud.aws.s3.credentials.access-key}")
+    private String accessKey;
+    @Value("${spring.cloud.aws.s3.credentials.secret-key}")
+    private String secretKey;
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/zoo/insightnote/global/config/SwaggerConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/SwaggerConfig.java
@@ -1,4 +1,24 @@
 package zoo.insightnote.global.config;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Springdoc 테스트")
+                .description("Springdoc을 사용한 Swagger UI 테스트")
+                .version("1.0.0");
+    }
 }

--- a/src/main/java/zoo/insightnote/global/entity/BaseTimeEntity.java
+++ b/src/main/java/zoo/insightnote/global/entity/BaseTimeEntity.java
@@ -1,10 +1,13 @@
 package zoo.insightnote.global.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.EntityListeners;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
@@ -12,7 +15,13 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
+
     private LocalDateTime deletedAt;
 }

--- a/src/main/java/zoo/insightnote/global/exception/ErrorCode.java
+++ b/src/main/java/zoo/insightnote/global/exception/ErrorCode.java
@@ -5,7 +5,11 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-    ;
+
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ID의 이벤트가 존재하지 않습니다."),;
+
+
+
     private final HttpStatus errorCode;
     private final String errorMessage;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,28 @@
 spring:
-  application:
-    name: InsightNote
+  config:
+    import: "optional:file:.env[.properties]"
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DATABASE_URL}
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+
+  jpa:
+    show-sql: true
+    generate-ddl: true
+    hibernate:
+      ddl-auto: update
+      default_batch_fetch_size: 100
+
+  cloud:
+    aws:
+      s3:
+        credentials:
+          accessKey: ${AWS_S3_ACCESSKEY}
+          secretKey: ${AWS_S3_SECRETKEY}
+        bucket: ${AWS_S3_BUCKET}
+      region:
+        static: ${AWS_REGION}
+      stack:
+        auto: false

--- a/src/test/java/zoo/insightnote/domain/event/service/EventServiceTest.java
+++ b/src/test/java/zoo/insightnote/domain/event/service/EventServiceTest.java
@@ -1,0 +1,155 @@
+package zoo.insightnote.domain.event.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import zoo.insightnote.domain.event.dto.req.EventRequestDto;
+import zoo.insightnote.domain.event.dto.req.EventUpdateRequestDto;
+import zoo.insightnote.domain.event.dto.res.EventResponseDto;
+import zoo.insightnote.domain.event.entity.Event;
+import zoo.insightnote.domain.event.repository.EventRepository;
+import zoo.insightnote.domain.image.entity.EntityType;
+import zoo.insightnote.domain.image.entity.Image;
+import zoo.insightnote.domain.image.repository.ImageRepository;
+import zoo.insightnote.domain.s3.service.S3Service;
+import zoo.insightnote.global.exception.CustomException;
+import zoo.insightnote.global.exception.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private ImageRepository imageRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @InjectMocks
+    private EventService eventService;
+
+    private Event event;
+    private EventRequestDto requestDto;
+    private EventUpdateRequestDto updateRequestDto;
+
+    @BeforeEach
+    void setUp() {
+        event = Event.builder()
+                .name("기존 이벤트")
+                .description("기존 설명")
+                .location("서울")
+                .startTime(null)
+                .endTime(null)
+                .build();
+
+        // 신규 생성시 image1,image2 이미지 있다고 가정
+        requestDto = new EventRequestDto(
+                "새로운 이벤트",
+                "새로운 설명",
+                "부산",
+                null,
+                null,
+                List.of("image1.jpg", "image2.jpg")
+        );
+
+        // 업데이트 경우 기존의 image1 삭제하고 새로운 image3 추가
+        updateRequestDto = new EventUpdateRequestDto(
+                "수정된 이벤트",
+                "수정된 설명",
+                "제주",
+                null,
+                null,
+                List.of("image2.jpg", "image3.jpg")
+        );
+    }
+
+    @Test
+    @DisplayName("[이벤트 생성 성공] 새로운 이벤트를 생성하면 요청한 정보를 저장하고, 클라이언트가 전달한 이미지도 함께 저장된다.")
+    void createEvent_success() {
+        // Given
+        when(eventRepository.save(any(Event.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // When
+        EventResponseDto response = eventService.createEvent(requestDto);
+
+        // Then
+        assertThat(response.name()).isEqualTo("새로운 이벤트");
+        assertThat(response.description()).isEqualTo("새로운 설명");
+        assertThat(response.location()).isEqualTo("부산");
+
+        verify(imageRepository, times(1)).saveAll(
+                argThat((List<Image> images) ->
+                        images != null && images.stream()
+                                .map(Image::getFileUrl)
+                                .equals(List.of("image1.jpg", "image2.jpg"))
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("[이벤트 수정 성공] 기존 이미지 중 삭제된 이미지는 제거하고, 새로운 이미지는 추가 저장된다.")
+    void updateEvent_success() {
+        // Given
+        when(eventRepository.findById(any(Long.class))).thenReturn(Optional.of(event));
+
+        // 기존 저장된 이미지 리스트 (image1, image2)
+        List<Image> existingImages = new ArrayList<>(List.of(
+                Image.of("event-image", "image1.jpg", 1L, EntityType.EVENT),
+                Image.of("event-image", "image2.jpg", 1L, EntityType.EVENT)
+        ));
+
+        when(imageRepository.findByEntityIdAndEntityType(any(Long.class), eq(EntityType.EVENT)))
+                .thenReturn(existingImages);
+
+        // When
+        EventResponseDto response = eventService.updateEvent(1L, updateRequestDto);
+
+        // Then
+        assertThat(response.name()).isEqualTo("수정된 이벤트");
+        assertThat(response.description()).isEqualTo("수정된 설명");
+        assertThat(response.location()).isEqualTo("제주");
+
+        // 삭제된 이미지 (image1) 검증
+        // verify라 실제로 s3에서 이미지가 삭제되었는지 확인하지는 않습니다.
+        verify(s3Service, times(1)).deleteImages(List.of("image1.jpg"));
+        verify(imageRepository, times(1)).deleteByFileUrlIn(List.of("image1.jpg"));
+
+        // 추가된 이미지 (image3) 검증
+        verify(imageRepository, times(1)).saveAll(
+                argThat((List<Image> images) -> images != null && images.stream()
+                        .map(Image::getFileUrl)
+                        .anyMatch(url -> url.equals("image3.jpg"))
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("[이벤트 수정 실패] 존재하지 않는 이벤트 ID로 요청하면 EVENT_NOT_FOUND 예외 발생한다 ")
+    void updateEvent_fail_notFound() {
+        // Given
+        when(eventRepository.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        // Then
+        assertThatThrownBy(() -> eventService.updateEvent(1L, updateRequestDto))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EVENT_NOT_FOUND)
+                .hasMessage(ErrorCode.EVENT_NOT_FOUND.getErrorMessage());
+    }
+}


### PR DESCRIPTION
## Summary

>- #2 

컨벤션 crud api와 s3 presigned URL 을 사용한 이미지 저장을 적용했습니다 

## Tasks

- 컨벤션 crud API 추가 
- S3 설정 추가
- 테스트 코드 추가 (서비스 코드 생성,수정만 )

## To Reviewer

- s3에 이미지를 저장하는 도메인은 총4가지가 있어서 타입별로 이미지 폴더로 생성하게 구성했습니다 
- s3 이미지에 대한 리사이징이나 캐싱 , 람다 함수 사용 등 더 고려할사항이 많지만 일단 기능 구현을 목표로 1차로 끝냈습니다 
   -  클라이언트가 s3에 직업 업로드 요청하는 경우 버킷 이름이 노출됨 (이거는 노출되면 버킷 트래픽 공격받으면 과금발생 가능성 있음)
   -  s3에서 클라이언트가 파일을 읽게 하면 버킷 이름이 노출되기 때문에 CDN 서비스를 붙여서 해결하는게 안전함   

- .env 파일을 추가했기 때문에 해당 파일을 공유드리겠습니다 



## Screenshot

왜 presigned URL 사용했나요?  
-저희 프로젝트가 대규모 운영사이트라 사용자가 많다고 가정하고 수많은 사람이 요청을 할건데 서버에 부담을 줄이는것을 고려했습니다 
![스크린샷 2025-03-05 오후 3 58 35](https://github.com/user-attachments/assets/1f70015b-0e9f-4a35-b0c0-611463101600)

presigned URL 동작 원리는 아래와 같습니다  아래 5번 스텝에서 추가 스텝이 있는데
5번까지 진행한후 클라이언트에서 s3에 이미지 업로드를 마치고 업로드한 이미지 목록과 행사 생성 요청을 같이 날려서 서버에서 저장을 합니다  
![스크린샷 2025-03-05 오후 3 58 44](https://github.com/user-attachments/assets/a32f8d8b-7ce3-4829-b5e9-c2cb16adff90)

presigned URL 응답 사진 
![스크린샷 2025-03-05 오후 4 44 08](https://github.com/user-attachments/assets/87ed8f4b-7e02-4323-bddf-03f947e3887a)

s3 버킷에 저장잘되었는지 확인
![스크린샷 2025-03-05 오후 4 43 36](https://github.com/user-attachments/assets/a99aeecd-c8b0-4ea7-8ac8-8942f28943ae)
