### PR TITLE
[#8] 인사이트 노트 대댓글 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/zoo/insightnote/domain/comment/service/CommentService.java
+++ b/src/main/java/zoo/insightnote/domain/comment/service/CommentService.java
@@ -35,7 +35,7 @@ public class CommentService {
 
         Comment comment = CommentMapper.toEntity(insight, user, request);
 
-        comment = commentRepository.save(comment);
+        commentRepository.save(comment);
 
         return CommentMapper.toResponse(comment);
     }
@@ -75,7 +75,7 @@ public class CommentService {
         return new CommentResponse.Delete(commentId);
     }
 
-    private Comment findCommentById(Long commentId) {
+    public Comment findCommentById(Long commentId) {
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
     }

--- a/src/main/java/zoo/insightnote/domain/reply/controller/ReplyController.java
+++ b/src/main/java/zoo/insightnote/domain/reply/controller/ReplyController.java
@@ -1,4 +1,45 @@
 package zoo.insightnote.domain.reply.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import zoo.insightnote.domain.reply.dto.ReplyRequest;
+import zoo.insightnote.domain.reply.dto.ReplyResponse;
+
+@Tag(name = "Reply API", description = "대댓글 관련 API")
 public interface ReplyController {
+
+    @Operation(summary = "대댓글 작성", description = "사용자가 특정 댓글에 대댓글을 작성합니다.")
+    ResponseEntity<ReplyResponse> writeReply(
+            @Parameter(description = "인사이트 ID") @PathVariable Long insightId,
+            @Parameter(description = "댓글 ID") @PathVariable Long commentId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody ReplyRequest.Create request);
+
+    @Operation(summary = "대댓글 목록 조회", description = "특정 댓글에 대한 대댓글 목록을 조회합니다.")
+    ResponseEntity<List<ReplyResponse>> listReplies(
+            @Parameter(description = "인사이트 ID") @PathVariable Long insightId,
+            @Parameter(description = "댓글 ID") @PathVariable Long commentId);
+
+    @Operation(summary = "대댓글 수정", description = "작성자가 본인의 대댓글을 수정합니다.")
+    ResponseEntity<ReplyResponse> updateReply(
+            @Parameter(description = "인사이트 ID") @PathVariable Long insightId,
+            @Parameter(description = "댓글 ID") @PathVariable Long commentId,
+            @Parameter(description = "대댓글 ID") @PathVariable Long replyId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody ReplyRequest.Update request);
+
+    @Operation(summary = "대댓글 삭제", description = "작성자가 본인의 대댓글을 삭제합니다.")
+    ResponseEntity<ReplyResponse> deleteReply(
+            @Parameter(description = "인사이트 ID") @PathVariable Long insightId,
+            @Parameter(description = "댓글 ID") @PathVariable Long commentId,
+            @Parameter(description = "대댓글 ID") @PathVariable Long replyId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails);
 }

--- a/src/main/java/zoo/insightnote/domain/reply/controller/ReplyControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/reply/controller/ReplyControllerImpl.java
@@ -19,6 +19,10 @@ import zoo.insightnote.domain.reply.dto.ReplyRequest;
 import zoo.insightnote.domain.reply.dto.ReplyResponse;
 import zoo.insightnote.domain.reply.service.ReplyService;
 
+/**
+ * TODO : SQL 성능 개선 및 리팩토링
+ */
+
 @RestController
 @RequestMapping("/api/v1/insights")
 @RequiredArgsConstructor
@@ -28,54 +32,53 @@ public class ReplyControllerImpl implements ReplyController {
 
     @Override
     @PostMapping("/{insightId}/comments/{commentId}/replies")
-    public ResponseEntity<ReplyResponse> writeReply(@PathVariable Long insightId,
-                                                    @PathVariable Long commentId,
-                                                    @AuthenticationPrincipal UserDetails userDetails,
-                                                    @RequestBody ReplyRequest.Create request) {
+    public ResponseEntity<ReplyResponse> writeReply(
+            @PathVariable Long insightId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody ReplyRequest.Create request)
+    {
         userDetails = validateUser(userDetails);
-
         ReplyResponse response = replyService.createReply(commentId, Long.valueOf(userDetails.getUsername()), request);
-
         return ResponseEntity.ok().body(response);
     }
 
 
     @Override
     @GetMapping("/{insightId}/comments/{commentId}/replies")
-    public ResponseEntity<List<ReplyResponse>> listReplies(@PathVariable Long insightId,
-                                                           @PathVariable Long commentId) {
+    public ResponseEntity<List<ReplyResponse>> listReplies(
+            @PathVariable Long insightId,
+            @PathVariable Long commentId)
+    {
         List<ReplyResponse> response = replyService.findRepliesByCommentId(commentId);
-
         return ResponseEntity.ok().body(response);
     }
 
 
     @Override
     @PutMapping("/{insightId}/comments/{commentId}/{replyId}")
-    public ResponseEntity<ReplyResponse> updateReply(@PathVariable Long insightId,
-                                                     @PathVariable Long commentId,
-                                                     @PathVariable Long replyId,
-                                                     @AuthenticationPrincipal UserDetails userDetails,
-                                                     @RequestBody ReplyRequest.Update request) {
-
+    public ResponseEntity<ReplyResponse> updateReply(
+            @PathVariable Long insightId,
+            @PathVariable Long commentId,
+            @PathVariable Long replyId,
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody ReplyRequest.Update request)
+    {
         userDetails = validateUser(userDetails);
-
-        ReplyResponse response = replyService.updateReply(commentId, replyId,
-                Long.valueOf(userDetails.getUsername()), request);
-
+        ReplyResponse response = replyService.updateReply(commentId, replyId, Long.valueOf(userDetails.getUsername()), request);
         return ResponseEntity.ok().body(response);
     }
     @Override
     @DeleteMapping("/{insightId}/comments/{commentId}/{replyId}")
-    public ResponseEntity<ReplyResponse> deleteReply(@PathVariable Long insightId,
-                                                     @PathVariable Long commentId,
-                                                     @PathVariable Long replyId,
-                                                     @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<ReplyResponse> deleteReply(
+            @PathVariable Long insightId,
+            @PathVariable Long commentId,
+            @PathVariable Long replyId,
+            @AuthenticationPrincipal UserDetails userDetails)
+    {
         userDetails = validateUser(userDetails);
-
         ReplyResponse response = replyService.deleteReply(commentId, replyId,
                 Long.valueOf(userDetails.getUsername()));
-
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/zoo/insightnote/domain/reply/controller/ReplyControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/reply/controller/ReplyControllerImpl.java
@@ -7,9 +7,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,6 +42,34 @@ public class ReplyControllerImpl implements ReplyController {
     public ResponseEntity<List<ReplyResponse>> listReplies(@PathVariable String insightId,
                                                            @PathVariable Long commentId) {
         List<ReplyResponse> response = replyService.findRepliesByCommentId(commentId);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PutMapping("/{insightId}/comments/{commentId}/{replyId}")
+    public ResponseEntity<ReplyResponse> updateReply(@PathVariable Long insightId,
+                                                     @PathVariable Long commentId,
+                                                     @PathVariable Long replyId,
+                                                     @AuthenticationPrincipal UserDetails userDetails,
+                                                     @RequestBody ReplyRequest.Update request) {
+
+        userDetails = validateUser(userDetails);
+
+        ReplyResponse response = replyService.updateReply(commentId, replyId,
+                Long.valueOf(userDetails.getUsername()), request);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @DeleteMapping("/{insightId}/comments/{commentId}/{replyId}")
+    public ResponseEntity<ReplyResponse> deleteReply(@PathVariable Long insightId,
+                                                     @PathVariable Long commentId,
+                                                     @PathVariable Long replyId,
+                                                     @AuthenticationPrincipal UserDetails userDetails) {
+        userDetails = validateUser(userDetails);
+
+        ReplyResponse response = replyService.deleteReply(commentId, replyId,
+                Long.valueOf(userDetails.getUsername()));
 
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/zoo/insightnote/domain/reply/controller/ReplyControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/reply/controller/ReplyControllerImpl.java
@@ -26,6 +26,7 @@ public class ReplyControllerImpl implements ReplyController {
 
     private final ReplyService replyService;
 
+    @Override
     @PostMapping("/{insightId}/comments/{commentId}/replies")
     public ResponseEntity<ReplyResponse> writeReply(@PathVariable Long insightId,
                                                     @PathVariable Long commentId,
@@ -38,14 +39,18 @@ public class ReplyControllerImpl implements ReplyController {
         return ResponseEntity.ok().body(response);
     }
 
+
+    @Override
     @GetMapping("/{insightId}/comments/{commentId}/replies")
-    public ResponseEntity<List<ReplyResponse>> listReplies(@PathVariable String insightId,
+    public ResponseEntity<List<ReplyResponse>> listReplies(@PathVariable Long insightId,
                                                            @PathVariable Long commentId) {
         List<ReplyResponse> response = replyService.findRepliesByCommentId(commentId);
 
         return ResponseEntity.ok().body(response);
     }
 
+
+    @Override
     @PutMapping("/{insightId}/comments/{commentId}/{replyId}")
     public ResponseEntity<ReplyResponse> updateReply(@PathVariable Long insightId,
                                                      @PathVariable Long commentId,
@@ -60,7 +65,7 @@ public class ReplyControllerImpl implements ReplyController {
 
         return ResponseEntity.ok().body(response);
     }
-
+    @Override
     @DeleteMapping("/{insightId}/comments/{commentId}/{replyId}")
     public ResponseEntity<ReplyResponse> deleteReply(@PathVariable Long insightId,
                                                      @PathVariable Long commentId,

--- a/src/main/java/zoo/insightnote/domain/reply/controller/ReplyControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/reply/controller/ReplyControllerImpl.java
@@ -1,11 +1,13 @@
 package zoo.insightnote.domain.reply.controller;
 
 import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,7 +20,7 @@ import zoo.insightnote.domain.reply.service.ReplyService;
 @RestController
 @RequestMapping("/api/v1/insights")
 @RequiredArgsConstructor
-public class ReplyControllerImpl implements ReplyController{
+public class ReplyControllerImpl implements ReplyController {
 
     private final ReplyService replyService;
 
@@ -30,6 +32,14 @@ public class ReplyControllerImpl implements ReplyController{
         userDetails = validateUser(userDetails);
 
         ReplyResponse response = replyService.createReply(commentId, Long.valueOf(userDetails.getUsername()), request);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/{insightId}/comments/{commentId}/replies")
+    public ResponseEntity<List<ReplyResponse>> listReplies(@PathVariable String insightId,
+                                                           @PathVariable Long commentId) {
+        List<ReplyResponse> response = replyService.findRepliesByCommentId(commentId);
 
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/zoo/insightnote/domain/reply/controller/ReplyControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/reply/controller/ReplyControllerImpl.java
@@ -1,7 +1,44 @@
 package zoo.insightnote.domain.reply.controller;
 
-import org.springframework.stereotype.Controller;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import zoo.insightnote.domain.reply.dto.ReplyRequest;
+import zoo.insightnote.domain.reply.dto.ReplyResponse;
+import zoo.insightnote.domain.reply.service.ReplyService;
 
-@Controller
+@RestController
+@RequestMapping("/api/v1/insights")
+@RequiredArgsConstructor
 public class ReplyControllerImpl implements ReplyController{
+
+    private final ReplyService replyService;
+
+    @PostMapping("/{insightId}/comments/{commentId}/replies")
+    public ResponseEntity<ReplyResponse> writeReply(@PathVariable Long insightId,
+                                                    @PathVariable Long commentId,
+                                                    @AuthenticationPrincipal UserDetails userDetails,
+                                                    @RequestBody ReplyRequest.Create request) {
+        userDetails = validateUser(userDetails);
+
+        ReplyResponse response = replyService.createReply(commentId, Long.valueOf(userDetails.getUsername()), request);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    // 임시 로직
+    private UserDetails validateUser(UserDetails userDetails) {
+        if (userDetails != null) {
+            return userDetails;
+        }
+        return new User("001", "password", Collections.emptyList());
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/reply/dto/ReplyRequest.java
+++ b/src/main/java/zoo/insightnote/domain/reply/dto/ReplyRequest.java
@@ -1,0 +1,7 @@
+package zoo.insightnote.domain.reply.dto;
+
+public interface ReplyRequest {
+    record Create(String content) implements ReplyRequest{
+
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/reply/dto/ReplyRequest.java
+++ b/src/main/java/zoo/insightnote/domain/reply/dto/ReplyRequest.java
@@ -4,4 +4,8 @@ public interface ReplyRequest {
     record Create(String content) implements ReplyRequest{
 
     }
+
+    record Update(String content){
+
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/reply/dto/ReplyResponse.java
+++ b/src/main/java/zoo/insightnote/domain/reply/dto/ReplyResponse.java
@@ -1,0 +1,10 @@
+package zoo.insightnote.domain.reply.dto;
+
+import java.time.LocalDateTime;
+
+public interface ReplyResponse {
+    record Default(Long parentCommentId, Long childCommentId, String content, LocalDateTime createAt,
+                   String author) implements ReplyResponse {
+
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/reply/entity/Reply.java
+++ b/src/main/java/zoo/insightnote/domain/reply/entity/Reply.java
@@ -12,6 +12,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import zoo.insightnote.domain.comment.entity.Comment;
 import zoo.insightnote.domain.user.entity.User;
 import zoo.insightnote.global.entity.BaseTimeEntity;
@@ -32,6 +34,7 @@ public class Reply extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Comment comment;
 
     private String content;

--- a/src/main/java/zoo/insightnote/domain/reply/entity/Reply.java
+++ b/src/main/java/zoo/insightnote/domain/reply/entity/Reply.java
@@ -8,12 +8,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import zoo.insightnote.domain.comment.entity.Comment;
 import zoo.insightnote.domain.user.entity.User;
 import zoo.insightnote.global.entity.BaseTimeEntity;
 
 @Entity
+@Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reply extends BaseTimeEntity {
     @Id

--- a/src/main/java/zoo/insightnote/domain/reply/entity/Reply.java
+++ b/src/main/java/zoo/insightnote/domain/reply/entity/Reply.java
@@ -38,4 +38,10 @@ public class Reply extends BaseTimeEntity {
     private Comment comment;
 
     private String content;
+
+    public void update(String content) {
+        if (content != null) {
+            this.content = content;
+        }
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/reply/mapper/ReplyMapper.java
+++ b/src/main/java/zoo/insightnote/domain/reply/mapper/ReplyMapper.java
@@ -1,0 +1,27 @@
+package zoo.insightnote.domain.reply.mapper;
+
+import zoo.insightnote.domain.comment.entity.Comment;
+import zoo.insightnote.domain.reply.dto.ReplyResponse;
+import zoo.insightnote.domain.reply.dto.ReplyResponse.Default;
+import zoo.insightnote.domain.reply.entity.Reply;
+import zoo.insightnote.domain.user.entity.User;
+
+public class ReplyMapper {
+    public static Reply toEntity(Comment comment, User user, String content) {
+        return Reply.builder()
+                .comment(comment)
+                .user(user)
+                .content(content)
+                .build();
+    }
+
+    public static ReplyResponse toResponse(Reply reply) {
+        return new Default(
+                reply.getComment().getId(),
+                reply.getId(),
+                reply.getContent(),
+                reply.getCreateAt(),
+                reply.getUser().getName()
+        );
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/reply/repository/ReplyRepository.java
+++ b/src/main/java/zoo/insightnote/domain/reply/repository/ReplyRepository.java
@@ -1,8 +1,12 @@
 package zoo.insightnote.domain.reply.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
 import zoo.insightnote.domain.reply.entity.Reply;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
+
+    @Query("SELECT r FROM Reply r where r.comment.id = :commentId")
+    List<Reply> findAllByCommentId(Long commentId);
 }

--- a/src/main/java/zoo/insightnote/domain/reply/service/ReplyService.java
+++ b/src/main/java/zoo/insightnote/domain/reply/service/ReplyService.java
@@ -1,7 +1,47 @@
 package zoo.insightnote.domain.reply.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import zoo.insightnote.domain.comment.entity.Comment;
+import zoo.insightnote.domain.comment.service.CommentService;
+import zoo.insightnote.domain.reply.dto.ReplyRequest;
+import zoo.insightnote.domain.reply.dto.ReplyResponse;
+import zoo.insightnote.domain.reply.entity.Reply;
+import zoo.insightnote.domain.reply.mapper.ReplyMapper;
+import zoo.insightnote.domain.reply.repository.ReplyRepository;
+import zoo.insightnote.domain.user.entity.User;
+import zoo.insightnote.domain.user.repository.UserRepository;
+import zoo.insightnote.global.exception.CustomException;
+import zoo.insightnote.global.exception.ErrorCode;
 
 @Service
+@RequiredArgsConstructor
 public class ReplyService {
+
+    private final ReplyRepository replyRepository;
+    private final CommentService commentService;
+    private final UserRepository userRepository;
+
+    public ReplyResponse createReply(Long commentId, Long userId, ReplyRequest.Create request) {
+
+        Comment comment = hasComment(commentId);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(null, "사용자를 찾을 수 없습니다."));
+
+        Reply reply = ReplyMapper.toEntity(comment, user, request.content());
+
+        replyRepository.save(reply);
+
+        return ReplyMapper.toResponse(reply);
+    }
+
+    private Comment hasComment(Long commentId) {
+        try {
+            return commentService.findCommentById(commentId);
+        } catch (CustomException e) {
+            throw new CustomException(ErrorCode.DELETED_COMMENT_CANNOT_HAVE_REPLY);
+        }
+    }
+
 }

--- a/src/main/java/zoo/insightnote/domain/reply/service/ReplyService.java
+++ b/src/main/java/zoo/insightnote/domain/reply/service/ReplyService.java
@@ -29,8 +29,7 @@ public class ReplyService {
 
         Comment comment = hasComment(commentId);
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(null, "사용자를 찾을 수 없습니다."));
+        User user = findUserById(userId);
 
         Reply reply = ReplyMapper.toEntity(comment, user, request.content());
 
@@ -51,7 +50,6 @@ public class ReplyService {
         return responses;
     }
 
-    // existsById();
     private Comment hasComment(Long commentId) {
         try {
             return commentService.findCommentById(commentId);
@@ -64,8 +62,7 @@ public class ReplyService {
 
         hasComment(commentId);
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(null, "사용자를 찾을 수 없습니다."));
+        User user = findUserById(userId);
 
         Reply reply = findReplyById(replyId);
 
@@ -80,8 +77,7 @@ public class ReplyService {
 
         hasComment(commentId);
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(null, "사용자를 찾을 수 없습니다."));
+        User user = findUserById(userId);
 
         Reply reply = findReplyById(replyId);
 
@@ -92,6 +88,11 @@ public class ReplyService {
         return ReplyMapper.toResponse(reply);
     }
 
+    // TODO : 유저 도메인 개발 완료시 삭제
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(null, "사용자를 찾을 수 없습니다."));
+    }
 
     public Reply findReplyById(Long replyId) {
         return replyRepository.findById(replyId)

--- a/src/main/java/zoo/insightnote/domain/reply/service/ReplyService.java
+++ b/src/main/java/zoo/insightnote/domain/reply/service/ReplyService.java
@@ -1,5 +1,7 @@
 package zoo.insightnote.domain.reply.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import zoo.insightnote.domain.comment.entity.Comment;
@@ -36,6 +38,19 @@ public class ReplyService {
         return ReplyMapper.toResponse(reply);
     }
 
+    public List<ReplyResponse> findRepliesByCommentId(Long commentId) {
+
+        List<Reply> replies = replyRepository.findAllByCommentId(commentId);
+
+        List<ReplyResponse> responses = new ArrayList<>();
+        for (Reply reply : replies) {
+            responses.add(ReplyMapper.toResponse(reply));
+        }
+
+        return responses;
+    }
+
+    // existsById();
     private Comment hasComment(Long commentId) {
         try {
             return commentService.findCommentById(commentId);

--- a/src/main/java/zoo/insightnote/global/exception/ErrorCode.java
+++ b/src/main/java/zoo/insightnote/global/exception/ErrorCode.java
@@ -8,7 +8,10 @@ public enum ErrorCode {
 
     //Comment ErrorCode
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
-    UNAUTHORIZED_COMMENT_MODIFICATION(HttpStatus.BAD_REQUEST, "작성자만 댓글을 수정할 수 있습니다.");
+    UNAUTHORIZED_COMMENT_MODIFICATION(HttpStatus.BAD_REQUEST, "작성자만 댓글을 수정할 수 있습니다."),
+
+    //Reply ErrorCode
+    DELETED_COMMENT_CANNOT_HAVE_REPLY(HttpStatus.BAD_REQUEST, "해당 댓글이 삭제되어 댓글을 작성할 수 없습니다.");
 
     private final HttpStatus errorCode;
     private final String errorMessage;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,18 @@
 spring:
   application:
     name: InsightNote
+
+  datasource:
+    url: jdbc:mysql://localhost:3307/joo?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: root1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show-sql: true
+

--- a/src/test/java/zoo/insightnote/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/zoo/insightnote/domain/comment/service/CommentServiceTest.java
@@ -82,7 +82,6 @@ class CommentServiceTest {
                 author.getId(), request);
 
         // then
-        assertThat(response.commentId()).isEqualTo(1L);
         assertThat(response.content()).isEqualTo("작성하신 노트 잘보았습니다!");
     }
 

--- a/src/test/java/zoo/insightnote/domain/reply/service/ReplyServiceTest.java
+++ b/src/test/java/zoo/insightnote/domain/reply/service/ReplyServiceTest.java
@@ -1,0 +1,123 @@
+package zoo.insightnote.domain.reply.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import zoo.insightnote.domain.comment.entity.Comment;
+import zoo.insightnote.domain.comment.service.CommentService;
+import zoo.insightnote.domain.reply.dto.ReplyRequest.Create;
+import zoo.insightnote.domain.reply.dto.ReplyResponse;
+import zoo.insightnote.domain.reply.entity.Reply;
+import zoo.insightnote.domain.reply.repository.ReplyRepository;
+import zoo.insightnote.domain.user.entity.User;
+import zoo.insightnote.domain.user.repository.UserRepository;
+import zoo.insightnote.global.exception.CustomException;
+import zoo.insightnote.global.exception.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class ReplyServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ReplyRepository replyRepository;
+
+    @Mock
+    private CommentService commentService;
+
+    @InjectMocks
+    ReplyService replyService;
+
+    Comment parentComment;
+
+    User parentAuthor;
+
+    User author;
+
+    Reply reply;
+
+    @BeforeEach
+    void beforeEach() {
+
+        parentAuthor = User.builder()
+                .id(1L)
+                .build();
+
+        parentComment = Comment.builder()
+                .id(1L)
+                .user(parentAuthor)
+                .content("작성하신 노트 잘보았습니다!")
+                .build();
+
+        author = User.builder()
+                .id(2L)
+                .build();
+
+
+        reply = Reply.builder()
+                .id(1L)
+                .comment(parentComment)
+                .user(author)
+                .content("작성하신 노트 잘보았습니다!")
+                .build();
+    }
+
+    @Test
+    @DisplayName("테스트 성공 : 부모 댓글이 존재하는 경우 사용자는 대댓글을 작성할 수 있다.")
+    void 사용자는_대댓글을_작성할_수_있다(){
+        //given
+        Create request = new Create("대댓글 작성 완료");
+
+        when(userRepository.findById(any())).thenReturn(Optional.of(author));
+        when(commentService.findCommentById(any())).thenReturn(parentComment);
+        when(replyRepository.save(any())).thenReturn(reply);
+
+        //when
+        ReplyResponse.Default response = (ReplyResponse.Default) replyService.createReply(parentComment.getId(), author.getId(), request);
+
+        //then
+        Assertions.assertThat(response.parentCommentId()).isEqualTo(parentComment.getId());
+        Assertions.assertThat(request.content()).isEqualTo(response.content());
+        verify(replyRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("테스트 실패 : 부모 댓글이 존재하지 않은 경우 댓글을 작성할 수 없다.")
+    void 이미_삭제된_댓글에는_댓글을_작성할_수_없다() {
+        // given
+        parentComment = Comment.builder()
+                .id(999L)
+                .user(parentAuthor)
+                .content("작성하신 노트 잘보았습니다!")
+                .build();
+
+        Create request = new Create("대댓글 작성 완료");
+
+        when(commentService.findCommentById(any()))
+                .thenThrow(new CustomException(ErrorCode.DELETED_COMMENT_CANNOT_HAVE_REPLY));
+
+        // when & then
+        Assertions.assertThatThrownBy(() ->
+                        replyService.createReply(parentComment.getId(), author.getId(), request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.DELETED_COMMENT_CANNOT_HAVE_REPLY.getErrorMessage());
+
+        verify(replyRepository, never()).save(any());
+    }
+
+
+
+}

--- a/src/test/java/zoo/insightnote/domain/reply/service/ReplyServiceTest.java
+++ b/src/test/java/zoo/insightnote/domain/reply/service/ReplyServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -116,6 +118,24 @@ class ReplyServiceTest {
                 .hasMessage(ErrorCode.DELETED_COMMENT_CANNOT_HAVE_REPLY.getErrorMessage());
 
         verify(replyRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("테스트 성공 : 사용자는 댓글에 달린 대댓글을 모두 조회할 수 있다.")
+    void 모든_대댓글_조회_성공() {
+        //given
+        List<Reply> replies = Arrays.asList(
+                new Reply(1L, author, parentComment, "대댓글1"),
+                new Reply(2L, author, parentComment, "대댓글1")
+        );
+
+        when(replyRepository.findAllByCommentId(parentComment.getId())).thenReturn(replies);
+
+        //when
+        List<ReplyResponse> responses = replyService.findRepliesByCommentId(parentComment.getId());
+
+        //then
+        Assertions.assertThat(replies.size()).isEqualTo(responses.size());
     }
 
 


### PR DESCRIPTION
## Summary

>- #8 
closes #8  
인사이트 노트에 달린 댓글에 대댓글을 작성할 수 있는 API를 개발하였습니다.

## Tasks

- 대댓글 작성 `/api/v1/insights/{insightId}/comments/{commentId}/replies`
- 대댓글 조회 `/api/v1/insights/{insightId}/comments/{commentId}/replies`
- 대댓글 수정 `/api/v1/insgihts/{insightId}/comments/{commentId}/{replyId}`
- 대댓글 삭제 `/api/v1/insgihts/{insightId}/comments/{commentId}/{replyId}`

## To Reviewer
`ReplyControllerImpl` 및 `ReplyService` 내에서 유저 관련 임시 코드가 포함되어 있으며, 기능 병합 후 수정할 예정입니다! 


## Screenshot

![image](https://github.com/user-attachments/assets/7de4afd9-07a0-4c0a-af46-5705b72afdcd)
