### PR TITLE
[#14] 세션 CRUD API 기능 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/zoo/insightnote/domain/event/dto/req/EventRequestDto.java
+++ b/src/main/java/zoo/insightnote/domain/event/dto/req/EventRequestDto.java
@@ -1,5 +1,7 @@
 package zoo.insightnote.domain.event.dto.req;
 
+import zoo.insightnote.domain.image.dto.ImageRequest;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -9,5 +11,5 @@ public record EventRequestDto(
         String location,
         LocalDateTime startTime,
         LocalDateTime endTime,
-        List<String> imageUrls
+        List<ImageRequest.UploadImage> images
 ) {}

--- a/src/main/java/zoo/insightnote/domain/event/dto/req/EventUpdateRequestDto.java
+++ b/src/main/java/zoo/insightnote/domain/event/dto/req/EventUpdateRequestDto.java
@@ -1,5 +1,7 @@
 package zoo.insightnote.domain.event.dto.req;
 
+import zoo.insightnote.domain.image.dto.ImageRequest;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -9,5 +11,5 @@ public record EventUpdateRequestDto(
         String location,
         LocalDateTime startTime,
         LocalDateTime endTime,
-        List<String> imageUrls
+        List<ImageRequest.UploadImage> images
 ) {}

--- a/src/main/java/zoo/insightnote/domain/event/entity/Event.java
+++ b/src/main/java/zoo/insightnote/domain/event/entity/Event.java
@@ -6,13 +6,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import lombok.*;
 
 @Entity
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Event {
     @Id

--- a/src/main/java/zoo/insightnote/domain/event/service/EventService.java
+++ b/src/main/java/zoo/insightnote/domain/event/service/EventService.java
@@ -8,15 +8,13 @@ import zoo.insightnote.domain.event.dto.req.EventRequestDto;
 import zoo.insightnote.domain.event.dto.res.EventResponseDto;
 import zoo.insightnote.domain.event.entity.Event;
 import zoo.insightnote.domain.event.repository.EventRepository;
+import zoo.insightnote.domain.image.dto.ImageRequest;
 import zoo.insightnote.domain.image.entity.EntityType;
-import zoo.insightnote.domain.image.entity.Image;
 import zoo.insightnote.domain.image.repository.ImageRepository;
+import zoo.insightnote.domain.image.service.ImageService;
 import zoo.insightnote.domain.s3.service.S3Service;
 import zoo.insightnote.global.exception.CustomException;
 import zoo.insightnote.global.exception.ErrorCode;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +22,7 @@ public class EventService {
     private final EventRepository eventRepository;
     private final ImageRepository imageRepository;
     private final S3Service s3Service;
+    private final ImageService imageService;
 
     @Transactional
     public EventResponseDto createEvent(EventRequestDto request) {
@@ -38,11 +37,7 @@ public class EventService {
         Event savedEvent = eventRepository.save(event);
 
         // 이미지 저장 (클라이언트에서 전달)
-        List<Image> images = request.imageUrls().stream()
-                .map(url -> Image.of("event-image", url, savedEvent.getId(), EntityType.EVENT))
-                .collect(Collectors.toList());
-
-        imageRepository.saveAll(images);
+        imageService.saveImages(savedEvent.getId(), EntityType.EVENT, request.images());
 
         return EventResponseDto.fromEntity(savedEvent);
     }
@@ -64,38 +59,11 @@ public class EventService {
         Event event = eventRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
 
-        // 기존 DB에 저장된 이미지 리스트 가져오기
-        List<String> existingImageUrls = imageRepository.findByEntityIdAndEntityType(event.getId(), EntityType.EVENT)
-                .stream()
-                .map(Image::getFileUrl)
-                .collect(Collectors.toList());
-
-        // 클라이언트에서 보낸 새로운 이미지 리스트
-        List<String> newImageUrls = request.imageUrls();
-
-        // 삭제할 이미지 찾기 (기존에 있었는데 요청에서는 사라진 이미지)
-        List<String> deletedImageUrls = existingImageUrls.stream()
-                .filter(url -> !newImageUrls.contains(url))
-                .collect(Collectors.toList());
-
-        // 추가할 이미지 찾기 (요청에서 새롭게 추가된 이미지)
-        List<String> addedImageUrls = newImageUrls.stream()
-                .filter(url -> !existingImageUrls.contains(url))
-                .collect(Collectors.toList());
-
-        // S3 & DB에서 삭제할 이미지가 있으면 삭제
-        if (!deletedImageUrls.isEmpty()) {
-            s3Service.deleteImages(deletedImageUrls);
-            imageRepository.deleteByFileUrlIn(deletedImageUrls);
-        }
-
-        // 새롭게 추가된 이미지 저장
-        if (!addedImageUrls.isEmpty()) {
-            List<Image> addedImages = addedImageUrls.stream()
-                    .map(url -> Image.of("event-image", url, event.getId(), EntityType.EVENT))
-                    .collect(Collectors.toList());
-            imageRepository.saveAll(addedImages);
-        }
+        imageService.updateImages(new ImageRequest.UploadImages(
+                event.getId(),
+                EntityType.EVENT,
+                request.images()
+        ));
 
         event.update(
                 request.name(),
@@ -113,15 +81,7 @@ public class EventService {
         Event event = eventRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
 
-        List<String> imageUrls = imageRepository.findByEntityIdAndEntityType(event.getId(), EntityType.EVENT)
-                .stream()
-                .map(Image::getFileUrl)
-                .collect(Collectors.toList());
-
-        if (!imageUrls.isEmpty()) {
-            s3Service.deleteImages(imageUrls);
-        }
-        imageRepository.deleteByEntityIdAndEntityType(event.getId(), EntityType.EVENT);
+        imageService.deleteImagesByEntity(event.getId(), EntityType.EVENT);
 
         eventRepository.delete(event);
     }

--- a/src/main/java/zoo/insightnote/domain/event/service/EventService.java
+++ b/src/main/java/zoo/insightnote/domain/event/service/EventService.java
@@ -47,6 +47,12 @@ public class EventService {
         return EventResponseDto.fromEntity(savedEvent);
     }
 
+    // 세션 생성시 이벤트 객체를 받기 위한 메서드
+    public Event findById(Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+    }
+
     public EventResponseDto getEventById(Long id) {
         Event event = eventRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));

--- a/src/main/java/zoo/insightnote/domain/image/dto/ImageRequest.java
+++ b/src/main/java/zoo/insightnote/domain/image/dto/ImageRequest.java
@@ -1,0 +1,20 @@
+package zoo.insightnote.domain.image.dto;
+
+import zoo.insightnote.domain.image.entity.EntityType;
+
+import java.util.List;
+
+public interface ImageRequest {
+    record UploadImage(
+            String fileName,
+            String fileUrl
+    ) implements ImageRequest {
+    }
+
+    record UploadImages(
+            Long entityId,
+            EntityType entityType,
+            List<UploadImage> images
+    ) implements ImageRequest {
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/image/service/ImageService.java
+++ b/src/main/java/zoo/insightnote/domain/image/service/ImageService.java
@@ -73,4 +73,20 @@ public class ImageService {
             imageRepository.saveAll(imagesToSave);
         }
     }
+
+    @Transactional
+    public void deleteImagesByEntity(Long entityId, EntityType entityType) {
+        List<Image> images = imageRepository.findByEntityIdAndEntityType(entityId, entityType);
+
+        if (images.isEmpty()) return;
+
+        List<String> imageUrls = images.stream()
+                .map(Image::getFileUrl)
+                .collect(Collectors.toList());
+
+        s3Service.deleteImages(imageUrls);
+
+        imageRepository.deleteByEntityIdAndEntityType(entityId, entityType);
+    }
+
 }

--- a/src/main/java/zoo/insightnote/domain/image/service/ImageService.java
+++ b/src/main/java/zoo/insightnote/domain/image/service/ImageService.java
@@ -3,9 +3,13 @@ package zoo.insightnote.domain.image.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import zoo.insightnote.domain.image.dto.ImageRequest;
 import zoo.insightnote.domain.image.entity.EntityType;
 import zoo.insightnote.domain.image.entity.Image;
 import zoo.insightnote.domain.image.repository.ImageRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -14,8 +18,16 @@ public class ImageService {
     private final ImageRepository imageRepository;
 
     @Transactional
-    public Image saveImage(String fileName, String fileUrl, EntityType entityType, Long entityId) {
-        Image image = Image.of(fileName, fileUrl, entityId, entityType);
-        return imageRepository.save(image);
+    public void saveImages(Long entityId, EntityType entityType, List<ImageRequest.UploadImage> images) {
+        if (images == null || images.isEmpty()) {
+            return;
+        }
+
+        List<Image> imageEntities = images.stream()
+                .map(image -> Image.of(image.fileName(), image.fileUrl(), entityId, entityType))
+                .collect(Collectors.toList());
+
+        imageRepository.saveAll(imageEntities);
     }
+
 }

--- a/src/main/java/zoo/insightnote/domain/session/controller/SessionController.java
+++ b/src/main/java/zoo/insightnote/domain/session/controller/SessionController.java
@@ -1,4 +1,61 @@
 package zoo.insightnote.domain.session.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import zoo.insightnote.domain.session.dto.SessionRequest;
+import zoo.insightnote.domain.session.dto.SessionResponse;
+
+@Tag(name = "SESSION", description = "세션 관련 API")
+@RequestMapping("/api/v1/sessions")
 public interface SessionController {
+
+    @Operation(summary = "세션 생성", description = "새로운 세션을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "세션 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping
+    ResponseEntity<SessionResponse.Default> createSession(
+            @RequestBody SessionRequest.Create request
+    );
+
+    @Operation(summary = "세션 수정", description = "기존 세션 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "세션 수정 성공"),
+            @ApiResponse(responseCode = "404", description = "세션을 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PutMapping("/{sessionId}")
+    ResponseEntity<SessionResponse.Default> updateSession(
+            @Parameter(description = "수정할 세션 ID") @PathVariable Long sessionId,
+            @RequestBody SessionRequest.Update request
+    );
+
+    @Operation(summary = "세션 삭제", description = "특정 ID의 세션을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "세션 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "세션을 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @DeleteMapping("/{sessionId}")
+    ResponseEntity<Void> deleteSession(
+            @Parameter(description = "삭제할 세션 ID") @PathVariable Long sessionId
+    );
+
+    @Operation(summary = "특정 세션 조회", description = "ID를 이용해 특정 세션 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "세션 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "세션을 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/{sessionId}")
+    ResponseEntity<SessionResponse.Default> getSessionById(
+            @Parameter(description = "조회할 세션 ID") @PathVariable Long sessionId
+    );
 }

--- a/src/main/java/zoo/insightnote/domain/session/controller/SessionControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/session/controller/SessionControllerImpl.java
@@ -10,9 +10,10 @@ import zoo.insightnote.domain.session.service.SessionService;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/sessions")
-public class SessionControllerImpl implements SessionController{
+public class SessionControllerImpl implements SessionController {
     private final SessionService sessionService;
 
+    @Override
     @PostMapping
     public ResponseEntity<SessionResponse.Default> createSession(
             @RequestBody SessionRequest.Create request
@@ -21,6 +22,7 @@ public class SessionControllerImpl implements SessionController{
         return ResponseEntity.ok(response);
     }
 
+    @Override
     @PutMapping("/{sessionId}")
     public ResponseEntity<SessionResponse.Default> updateSession(
             @PathVariable Long sessionId,
@@ -29,17 +31,18 @@ public class SessionControllerImpl implements SessionController{
         return ResponseEntity.ok(response);
     }
 
+    @Override
     @DeleteMapping("/{sessionId}")
     public ResponseEntity<Void> deleteSession(@PathVariable Long sessionId) {
         sessionService.deleteSession(sessionId);
         return ResponseEntity.noContent().build();
     }
 
+    @Override
     @GetMapping("/{sessionId}")
     public ResponseEntity<SessionResponse.Default> getSessionById(@PathVariable Long sessionId) {
         SessionResponse.Default response = sessionService.getSessionById(sessionId);
         return ResponseEntity.ok(response);
     }
-
 
 }

--- a/src/main/java/zoo/insightnote/domain/session/controller/SessionControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/session/controller/SessionControllerImpl.java
@@ -2,10 +2,7 @@ package zoo.insightnote.domain.session.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import zoo.insightnote.domain.session.dto.SessionRequest;
 import zoo.insightnote.domain.session.dto.SessionResponse;
 import zoo.insightnote.domain.session.service.SessionService;
@@ -23,4 +20,14 @@ public class SessionControllerImpl implements SessionController{
         SessionResponse.Default response = sessionService.createSession(request);
         return ResponseEntity.ok(response);
     }
+
+    @PutMapping("/{sessionId}")
+    public ResponseEntity<SessionResponse.Default> updateSession(
+            @PathVariable Long sessionId,
+            @RequestBody SessionRequest.Update request) {
+        SessionResponse.Default response = sessionService.updateSession(sessionId, request);
+        return ResponseEntity.ok(response);
+    }
+
+
 }

--- a/src/main/java/zoo/insightnote/domain/session/controller/SessionControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/session/controller/SessionControllerImpl.java
@@ -35,5 +35,11 @@ public class SessionControllerImpl implements SessionController{
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/{sessionId}")
+    public ResponseEntity<SessionResponse.Default> getSessionById(@PathVariable Long sessionId) {
+        SessionResponse.Default response = sessionService.getSessionById(sessionId);
+        return ResponseEntity.ok(response);
+    }
+
 
 }

--- a/src/main/java/zoo/insightnote/domain/session/controller/SessionControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/session/controller/SessionControllerImpl.java
@@ -1,7 +1,26 @@
 package zoo.insightnote.domain.session.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import zoo.insightnote.domain.session.dto.SessionRequest;
+import zoo.insightnote.domain.session.dto.SessionResponse;
+import zoo.insightnote.domain.session.service.SessionService;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/sessions")
 public class SessionControllerImpl implements SessionController{
+    private final SessionService sessionService;
+
+    @PostMapping
+    public ResponseEntity<SessionResponse.Default> createSession(
+            @RequestBody SessionRequest.Create request
+    ) {
+        SessionResponse.Default response = sessionService.createSession(request);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/session/controller/SessionControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/session/controller/SessionControllerImpl.java
@@ -29,5 +29,11 @@ public class SessionControllerImpl implements SessionController{
         return ResponseEntity.ok(response);
     }
 
+    @DeleteMapping("/{sessionId}")
+    public ResponseEntity<Void> deleteSession(@PathVariable Long sessionId) {
+        sessionService.deleteSession(sessionId);
+        return ResponseEntity.noContent().build();
+    }
+
 
 }

--- a/src/main/java/zoo/insightnote/domain/session/dto/SessionRequest.java
+++ b/src/main/java/zoo/insightnote/domain/session/dto/SessionRequest.java
@@ -1,0 +1,26 @@
+package zoo.insightnote.domain.session.dto;
+
+import zoo.insightnote.domain.image.dto.ImageRequest;
+import zoo.insightnote.domain.session.entity.SessionStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface SessionRequest {
+    record Create(
+            Long eventId,
+            Long speakerId,
+            Integer eventDay,
+            String name,
+            String shortDescription,
+            String longDescription,
+            Integer maxCapacity,
+            LocalDateTime startTime,
+            LocalDateTime endTime,
+            SessionStatus status,
+            String videoLink,
+            String location,
+            List<ImageRequest.UploadImage> images
+    ) implements SessionRequest {
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/session/dto/SessionRequest.java
+++ b/src/main/java/zoo/insightnote/domain/session/dto/SessionRequest.java
@@ -23,4 +23,18 @@ public interface SessionRequest {
             List<ImageRequest.UploadImage> images
     ) implements SessionRequest {
     }
+
+    record Update(
+            String name,
+            String shortDescription,
+            String longDescription,
+            Integer maxCapacity,
+            LocalDateTime startTime,
+            LocalDateTime endTime,
+            SessionStatus status,
+            String videoLink,
+            String location,
+            List<ImageRequest.UploadImage> images
+    ) implements SessionRequest {
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/session/dto/SessionResponse.java
+++ b/src/main/java/zoo/insightnote/domain/session/dto/SessionResponse.java
@@ -1,0 +1,20 @@
+package zoo.insightnote.domain.session.dto;
+
+import zoo.insightnote.domain.session.entity.SessionStatus;
+
+import java.time.LocalDateTime;
+
+public interface SessionResponse {
+    record Default(
+            Long id,
+            String name,
+            String shortDescription,
+            String longDescription,
+            Integer maxCapacity,
+            LocalDateTime startTime,
+            LocalDateTime endTime,
+            String location,
+            SessionStatus status
+    ) implements SessionResponse {
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/session/entity/Session.java
+++ b/src/main/java/zoo/insightnote/domain/session/entity/Session.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 
 import lombok.*;
 import zoo.insightnote.domain.event.entity.Event;
+import zoo.insightnote.domain.session.dto.SessionRequest;
 import zoo.insightnote.domain.speaker.entity.Speaker;
 
 @Entity
@@ -57,4 +58,16 @@ public class Session {
     private String videoLink;
 
     private String location;
+
+    public void update(SessionRequest.Update request) {
+        if (request.name() != null) this.name = request.name();
+        if (request.shortDescription() != null) this.shortDescription = request.shortDescription();
+        if (request.longDescription() != null) this.longDescription = request.longDescription();
+        if (request.maxCapacity() != null) this.maxCapacity = request.maxCapacity();
+        if (request.startTime() != null) this.startTime = request.startTime();
+        if (request.endTime() != null) this.endTime = request.endTime();
+        if (request.status() != null) this.status = request.status();
+        if (request.videoLink() != null) this.videoLink = request.videoLink();
+        if (request.location() != null) this.location = request.location();
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/session/entity/Session.java
+++ b/src/main/java/zoo/insightnote/domain/session/entity/Session.java
@@ -11,12 +11,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+
+import lombok.*;
 import zoo.insightnote.domain.event.entity.Event;
+import zoo.insightnote.domain.speaker.entity.Speaker;
 
 @Entity
+@Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class Session {
 
     @Id
@@ -27,10 +31,19 @@ public class Session {
     @JoinColumn(name = "event_id")
     private Event event;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "speaker_id", nullable = false)
+    private Speaker speaker;  // 연사 ID (FK)
+
+    @Column(nullable = false)
+    private Integer eventDay;
+
     private String name;
 
+    private String shortDescription;
+
     @Column(columnDefinition = "TEXT")
-    private String description;
+    private String longDescription;
 
     private Integer maxCapacity;
 
@@ -43,4 +56,5 @@ public class Session {
 
     private String videoLink;
 
+    private String location;
 }

--- a/src/main/java/zoo/insightnote/domain/session/mapper/SessionMapper.java
+++ b/src/main/java/zoo/insightnote/domain/session/mapper/SessionMapper.java
@@ -1,0 +1,42 @@
+package zoo.insightnote.domain.session.mapper;
+
+import zoo.insightnote.domain.event.entity.Event;
+import zoo.insightnote.domain.session.dto.SessionRequest;
+import zoo.insightnote.domain.session.dto.SessionResponse;
+import zoo.insightnote.domain.session.entity.Session;
+import zoo.insightnote.domain.speaker.entity.Speaker;
+
+public class SessionMapper {
+
+    public static Session toEntity(SessionRequest.Create request, Event event, Speaker speaker) {
+        return Session.builder()
+                .event(event)
+                .speaker(speaker)
+                .eventDay(request.eventDay())
+                .name(request.name())
+                .shortDescription(request.shortDescription())
+                .longDescription(request.longDescription())
+                .maxCapacity(request.maxCapacity())
+                .startTime(request.startTime())
+                .endTime(request.endTime())
+                .status(request.status())
+                .videoLink(request.videoLink())
+                .location(request.location())
+                .build();
+    }
+
+    // Session엔티티 객체를 dto에서 정의한 record르 변환
+    public static SessionResponse.Default toResponse(Session session) {
+        return new SessionResponse.Default(
+                session.getId(),
+                session.getName(),
+                session.getShortDescription(),
+                session.getLongDescription(),
+                session.getMaxCapacity(),
+                session.getStartTime(),
+                session.getEndTime(),
+                session.getLocation(),
+                session.getStatus()
+        );
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/session/repository/SessionRepository.java
+++ b/src/main/java/zoo/insightnote/domain/session/repository/SessionRepository.java
@@ -3,5 +3,8 @@ package zoo.insightnote.domain.session.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import zoo.insightnote.domain.session.entity.Session;
 
+import java.util.List;
+
 public interface SessionRepository extends JpaRepository<Session, Long> {
+    List<Session> findByEventId(Long eventId);
 }

--- a/src/main/java/zoo/insightnote/domain/session/repository/SessionRepository.java
+++ b/src/main/java/zoo/insightnote/domain/session/repository/SessionRepository.java
@@ -6,5 +6,4 @@ import zoo.insightnote.domain.session.entity.Session;
 import java.util.List;
 
 public interface SessionRepository extends JpaRepository<Session, Long> {
-    List<Session> findByEventId(Long eventId);
 }

--- a/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
+++ b/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
@@ -60,12 +60,12 @@ public class SessionService {
 
     @Transactional
     public void deleteSession(Long sessionId) {
-        if (!sessionRepository.existsById(sessionId)) {
-            throw new CustomException(ErrorCode.SESSION_NOT_FOUND);
-        }
-        imageService.deleteImagesByEntity(sessionId, EntityType.SESSION);
+        Session session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
+        
+        imageService.deleteImagesByEntity(session.getId(), EntityType.SESSION);
 
-        sessionRepository.deleteById(sessionId);
+        sessionRepository.delete(session);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
+++ b/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
@@ -36,9 +36,9 @@ public class SessionService {
 
         Session session = SessionMapper.toEntity(request, event, speaker);
 
-        sessionRepository.save(session);
+        Session savedSession = sessionRepository.save(session);
 
-        imageService.saveImages(session.getId(), EntityType.SESSION, request.images());
+        imageService.saveImages(savedSession.getId(), EntityType.SESSION, request.images());
 
         return SessionMapper.toResponse(session);
     }

--- a/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
+++ b/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
@@ -1,7 +1,43 @@
 package zoo.insightnote.domain.session.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import zoo.insightnote.domain.event.entity.Event;
+import zoo.insightnote.domain.event.service.EventService;
+import zoo.insightnote.domain.image.entity.EntityType;
+import zoo.insightnote.domain.session.dto.SessionRequest;
+import zoo.insightnote.domain.session.dto.SessionResponse;
+import zoo.insightnote.domain.session.entity.Session;
+import zoo.insightnote.domain.session.mapper.SessionMapper;
+import zoo.insightnote.domain.session.repository.SessionRepository;
+import zoo.insightnote.domain.speaker.entity.Speaker;
+import zoo.insightnote.domain.speaker.service.SpeakerService;
+import zoo.insightnote.domain.image.service.ImageService;
 
 @Service
+@RequiredArgsConstructor
 public class SessionService {
+
+    private final SessionRepository sessionRepository;
+    private final EventService eventService;
+    private final SpeakerService speakerService;
+    private final ImageService imageService;
+
+    @Transactional
+    public SessionResponse.Default createSession(SessionRequest.Create request) {
+
+        Event event = eventService.findById(request.eventId());
+
+        Speaker speaker = speakerService.findById(request.speakerId());
+
+        Session session = SessionMapper.toEntity(request, event, speaker);
+
+        sessionRepository.save(session);
+
+        imageService.saveImages(session.getId(), EntityType.SESSION, request.images());
+
+        return SessionMapper.toResponse(session);
+    }
+
 }

--- a/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
+++ b/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
@@ -57,4 +57,14 @@ public class SessionService {
 
         return SessionMapper.toResponse(session);
     }
+
+    @Transactional
+    public void deleteSession(Long sessionId) {
+        if (!sessionRepository.existsById(sessionId)) {
+            throw new CustomException(ErrorCode.SESSION_NOT_FOUND);
+        }
+        imageService.deleteImagesByEntity(sessionId, EntityType.SESSION);
+
+        sessionRepository.deleteById(sessionId);
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
+++ b/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import zoo.insightnote.domain.event.entity.Event;
 import zoo.insightnote.domain.event.service.EventService;
+import zoo.insightnote.domain.image.dto.ImageRequest;
 import zoo.insightnote.domain.image.entity.EntityType;
 import zoo.insightnote.domain.session.dto.SessionRequest;
 import zoo.insightnote.domain.session.dto.SessionResponse;
@@ -14,6 +15,8 @@ import zoo.insightnote.domain.session.repository.SessionRepository;
 import zoo.insightnote.domain.speaker.entity.Speaker;
 import zoo.insightnote.domain.speaker.service.SpeakerService;
 import zoo.insightnote.domain.image.service.ImageService;
+import zoo.insightnote.global.exception.CustomException;
+import zoo.insightnote.global.exception.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -40,4 +43,18 @@ public class SessionService {
         return SessionMapper.toResponse(session);
     }
 
+    @Transactional
+    public SessionResponse.Default updateSession(Long sessionId, SessionRequest.Update request) {
+        Session session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
+        session.update(request);
+
+        imageService.updateImages(new ImageRequest.UploadImages(
+                session.getId(),
+                EntityType.SESSION,
+                request.images()
+        ));
+
+        return SessionMapper.toResponse(session);
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
+++ b/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
@@ -67,4 +67,12 @@ public class SessionService {
 
         sessionRepository.deleteById(sessionId);
     }
+
+    @Transactional(readOnly = true)
+    public SessionResponse.Default getSessionById(Long sessionId) {
+        Session session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
+
+        return SessionMapper.toResponse(session);
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/speaker/entity/Speaker.java
+++ b/src/main/java/zoo/insightnote/domain/speaker/entity/Speaker.java
@@ -5,9 +5,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Speaker {
 

--- a/src/main/java/zoo/insightnote/domain/speaker/service/SpeakerService.java
+++ b/src/main/java/zoo/insightnote/domain/speaker/service/SpeakerService.java
@@ -1,4 +1,19 @@
 package zoo.insightnote.domain.speaker.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import zoo.insightnote.domain.speaker.entity.Speaker;
+import zoo.insightnote.domain.speaker.repository.SpeakerRepository;
+import zoo.insightnote.global.exception.CustomException;
+import zoo.insightnote.global.exception.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
 public class SpeakerService {
+    private final SpeakerRepository speakerRepository;
+
+    public Speaker findById(Long speakerId) {
+        return speakerRepository.findById(speakerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SPEAKER_NOT_FOUND));
+    }
 }

--- a/src/main/java/zoo/insightnote/global/exception/ErrorCode.java
+++ b/src/main/java/zoo/insightnote/global/exception/ErrorCode.java
@@ -9,6 +9,9 @@ public enum ErrorCode {
     // 행사
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ID의 이벤트가 존재하지 않습니다."),
 
+    // 연사
+    SPEAKER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 연사가 존재하지 않습니다."),
+
     // 댓글 
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     UNAUTHORIZED_COMMENT_MODIFICATION(HttpStatus.BAD_REQUEST, "작성자만 댓글을 수정할 수 있습니다."),

--- a/src/main/java/zoo/insightnote/global/exception/ErrorCode.java
+++ b/src/main/java/zoo/insightnote/global/exception/ErrorCode.java
@@ -9,6 +9,9 @@ public enum ErrorCode {
     // 행사
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ID의 이벤트가 존재하지 않습니다."),
 
+    // 세션
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 세션을 찾을 수 없습니다."),
+
     // 연사
     SPEAKER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 연사가 존재하지 않습니다."),
 

--- a/src/test/java/zoo/insightnote/domain/event/service/EventServiceTest.java
+++ b/src/test/java/zoo/insightnote/domain/event/service/EventServiceTest.java
@@ -4,12 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,9 +18,9 @@ import zoo.insightnote.domain.event.dto.req.EventUpdateRequestDto;
 import zoo.insightnote.domain.event.dto.res.EventResponseDto;
 import zoo.insightnote.domain.event.entity.Event;
 import zoo.insightnote.domain.event.repository.EventRepository;
+import zoo.insightnote.domain.image.dto.ImageRequest;
 import zoo.insightnote.domain.image.entity.EntityType;
-import zoo.insightnote.domain.image.entity.Image;
-import zoo.insightnote.domain.image.repository.ImageRepository;
+import zoo.insightnote.domain.image.service.ImageService;
 import zoo.insightnote.domain.s3.service.S3Service;
 import zoo.insightnote.global.exception.CustomException;
 import zoo.insightnote.global.exception.ErrorCode;
@@ -36,7 +32,7 @@ class EventServiceTest {
     private EventRepository eventRepository;
 
     @Mock
-    private ImageRepository imageRepository;
+    private ImageService imageService;
 
     @Mock
     private S3Service s3Service;
@@ -58,24 +54,28 @@ class EventServiceTest {
                 .endTime(null)
                 .build();
 
-        // 신규 생성시 image1,image2 이미지 있다고 가정
         requestDto = new EventRequestDto(
                 "새로운 이벤트",
                 "새로운 설명",
                 "부산",
                 null,
                 null,
-                List.of("image1.jpg", "image2.jpg")
+                List.of(
+                        new ImageRequest.UploadImage("image1.jpg", "https://s3.amazonaws.com/bucket/image1.jpg"),
+                        new ImageRequest.UploadImage("image2.jpg", "https://s3.amazonaws.com/bucket/image2.jpg")
+                )
         );
 
-        // 업데이트 경우 기존의 image1 삭제하고 새로운 image3 추가
         updateRequestDto = new EventUpdateRequestDto(
                 "수정된 이벤트",
                 "수정된 설명",
                 "제주",
                 null,
                 null,
-                List.of("image2.jpg", "image3.jpg")
+                List.of(
+                        new ImageRequest.UploadImage("image2.jpg", "https://s3.amazonaws.com/bucket/image2.jpg"),
+                        new ImageRequest.UploadImage("image3.jpg", "https://s3.amazonaws.com/bucket/image3.jpg")
+                )
         );
     }
 
@@ -94,50 +94,23 @@ class EventServiceTest {
         assertThat(response.description()).isEqualTo("새로운 설명");
         assertThat(response.location()).isEqualTo("부산");
 
-        verify(imageRepository, times(1)).saveAll(
-                argThat((List<Image> images) ->
-                        images != null && images.stream()
-                                .map(Image::getFileUrl)
-                                .equals(List.of("image1.jpg", "image2.jpg"))
-                )
-        );
+        verify(imageService, times(1)).saveImages(anyLong(), eq(EntityType.EVENT), anyList());
     }
 
     @Test
     @DisplayName("[이벤트 수정 성공] 기존 이미지 중 삭제된 이미지는 제거하고, 새로운 이미지는 추가 저장된다.")
     void updateEvent_success() {
-        // Given
+
         when(eventRepository.findById(any(Long.class))).thenReturn(Optional.of(event));
 
-        // 기존 저장된 이미지 리스트 (image1, image2)
-        List<Image> existingImages = new ArrayList<>(List.of(
-                Image.of("event-image", "image1.jpg", 1L, EntityType.EVENT),
-                Image.of("event-image", "image2.jpg", 1L, EntityType.EVENT)
-        ));
-
-        when(imageRepository.findByEntityIdAndEntityType(any(Long.class), eq(EntityType.EVENT)))
-                .thenReturn(existingImages);
-
-        // When
         EventResponseDto response = eventService.updateEvent(1L, updateRequestDto);
 
-        // Then
         assertThat(response.name()).isEqualTo("수정된 이벤트");
         assertThat(response.description()).isEqualTo("수정된 설명");
         assertThat(response.location()).isEqualTo("제주");
 
-        // 삭제된 이미지 (image1) 검증
-        // verify라 실제로 s3에서 이미지가 삭제되었는지 확인하지는 않습니다.
-        verify(s3Service, times(1)).deleteImages(List.of("image1.jpg"));
-        verify(imageRepository, times(1)).deleteByFileUrlIn(List.of("image1.jpg"));
-
-        // 추가된 이미지 (image3) 검증
-        verify(imageRepository, times(1)).saveAll(
-                argThat((List<Image> images) -> images != null && images.stream()
-                        .map(Image::getFileUrl)
-                        .anyMatch(url -> url.equals("image3.jpg"))
-                )
-        );
+        // verify여서 s3이미지가실제로 수정되는지는 확인하지 않습니다
+        verify(imageService, times(1)).updateImages(any(ImageRequest.UploadImages.class));
     }
 
     @Test

--- a/src/test/java/zoo/insightnote/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/zoo/insightnote/domain/session/service/SessionServiceTest.java
@@ -1,0 +1,149 @@
+package zoo.insightnote.domain.session.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import zoo.insightnote.domain.event.entity.Event;
+import zoo.insightnote.domain.event.service.EventService;
+import zoo.insightnote.domain.image.dto.ImageRequest;
+import zoo.insightnote.domain.image.entity.EntityType;
+import zoo.insightnote.domain.image.service.ImageService;
+import zoo.insightnote.domain.session.dto.SessionRequest;
+import zoo.insightnote.domain.session.dto.SessionResponse;
+import zoo.insightnote.domain.session.entity.Session;
+import zoo.insightnote.domain.session.entity.SessionStatus;
+import zoo.insightnote.domain.session.repository.SessionRepository;
+import zoo.insightnote.domain.speaker.entity.Speaker;
+import zoo.insightnote.domain.speaker.service.SpeakerService;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SessionServiceTest {
+
+    @Mock private SessionRepository sessionRepository;
+    @Mock private EventService eventService;
+    @Mock private SpeakerService speakerService;
+    @Mock private ImageService imageService;
+
+    @InjectMocks
+    private SessionService sessionService;
+
+    private Event event;
+    private Speaker speaker;
+    private Session session;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 Event, Speaker, Session 객체 초기화
+        event = new Event(1L, "Tech Conference", "Event Description", "Location",
+                LocalDateTime.now(), LocalDateTime.now().plusDays(1));
+
+        speaker = new Speaker(1L, "요한", "yohan@example.com", "010-1234-5678");
+
+        session = Session.builder()
+                .id(1L)
+                .event(event)
+                .speaker(speaker)
+                .eventDay(1)
+                .name("AI Workshop")
+                .shortDescription("짧은 설명")
+                .longDescription("긴 설명")
+                .maxCapacity(100)
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now().plusHours(2))
+                .status(SessionStatus.BEFORE_START) //
+                .videoLink("https://example.com")
+                .location("2층")
+                .build();
+    }
+
+    @Test
+    @DisplayName("[세션 생성] 세션을 생성하면 요청한 정보가 저장되고, 관련 이미지도 함께 저장되어야 한다." +
+            " / 현재 구현은 안되어 있지만 이미지와 S에 대한 테스트도 추가를 해야 할 것 같다")
+    void createSession_Success() {
+        //  Given (Mock 설정)
+        SessionRequest.Create request = new SessionRequest.Create(
+                event.getId(),
+                speaker.getId(),
+                session.getEventDay(),
+                session.getName(),
+                session.getShortDescription(),
+                session.getLongDescription(),
+                session.getMaxCapacity(),
+                session.getStartTime(),
+                session.getEndTime(),
+                session.getStatus(),
+                session.getVideoLink(),
+                session.getLocation(),
+                Collections.emptyList()
+        );
+
+        when(eventService.findById(event.getId())).thenReturn(event);
+        when(speakerService.findById(speaker.getId())).thenReturn(speaker);
+        when(sessionRepository.save(any(Session.class))).thenReturn(session);
+
+        //  When
+        SessionResponse.Default response = sessionService.createSession(request);
+
+        //  Then
+        assertNotNull(response);
+        assertEquals(session.getName(), response.name());
+        verify(sessionRepository, times(1)).save(any(Session.class));
+        verify(imageService, times(1)).saveImages(anyLong(), any(EntityType.class), anyList());
+    }
+
+    @Test
+    @DisplayName("[세션 수정] 세션을 수정하면 새로운 정보가 반영되고, 변경된 이미지도 업데이트되어야 한다. " +
+            "/ 현재 구현은 안되어 있지만 이미지와 S에 대한 테스트도 추가를 해야 할 것 같다")
+    void updateSession_Success() {
+        //  Given
+        SessionRequest.Update request = new SessionRequest.Update(
+                "세션1-2",
+                "짧은 설명 수정",
+                "긴 설명 수정",
+                150,
+                session.getStartTime(),
+                session.getEndTime(),
+                SessionStatus.COMPLETED,
+                "https://updated-link.com",
+                "1층",
+                Collections.emptyList()
+        );
+
+        when(sessionRepository.findById(session.getId())).thenReturn(Optional.of(session));
+
+        //  When
+        SessionResponse.Default response = sessionService.updateSession(session.getId(), request);
+
+        //  Then
+        assertNotNull(response);
+        assertEquals(request.name(), response.name());
+        assertEquals(request.shortDescription(), response.shortDescription());
+        verify(imageService, times(1)).updateImages(any(ImageRequest.UploadImages.class));
+    }
+
+    @Test
+    @DisplayName("[세션 삭제] 세션을 삭제하면 관련 이미지도 삭제되고, 세션 정보가 데이터베이스에서 제거되어야 한다.")
+    void deleteSession_Success() {
+        //  Given
+        when(sessionRepository.findById(session.getId())).thenReturn(Optional.of(session));
+
+        //  When
+        sessionService.deleteSession(session.getId());
+
+        //  Then
+        verify(imageService, times(1)).deleteImagesByEntity(session.getId(), EntityType.SESSION);
+        verify(sessionRepository, times(1)).delete(session);
+    }
+}


### PR DESCRIPTION
## Summary

>- #14 close
close #14

세션 도메인 CRUD api구현 

## Tasks

- 세션 도메인의 기본적인 생성,수정,삭제,조회를 구현
- 스웨거 테스트 진행
- 테스트 코드 작성

## To Reviewer
- 각 서비스에 사용되는 쿼리 검증(N+1이나 동시성문제는 없는지 등)은 추후에 테스트가 필요합니다 
- 이미지 도메인에 공통으로 사용되는 메서드를 정의 하여 이미지 저정 관련된 메서드를 다른 도메인에서 사용이 되게 설정했습니다 

[고민사항]
- 테스트 코드를 제대로 하려면 별도로 실제 s3에  대한 테스트 검증 추가가 필요 합니다 
- 세션 삭제시 발생하는 쿼리에서 이미지데이터가 3개면 쿼리를 한번씩 날려서 삭제 쿼리가 나가는것 같은데 이 부분에 대한 개선은 추 후에 확인해보겠습니다
![스크린샷 2025-03-06 오후 8 24 03](https://github.com/user-attachments/assets/fcd13e25-2224-476c-9969-a5d431ff877b)

## Screenshot


