### PR TITLE
[#17] insightNote 기본 CRUD 구현

### DIFF
--- a/src/main/java/zoo/insightnote/domain/insight/controller/InsightController.java
+++ b/src/main/java/zoo/insightnote/domain/insight/controller/InsightController.java
@@ -1,4 +1,61 @@
 package zoo.insightnote.domain.insight.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import zoo.insightnote.domain.insight.dto.InsightRequestDto;
+import zoo.insightnote.domain.insight.dto.InsightResponseDto;
+
+@Tag(name = "INSIGHT", description = "인사이트 관련 API")
+@RequestMapping("/api/v1/insights")
 public interface InsightController {
+
+    @Operation(summary = "인사이트 생성", description = "새로운 인사이트를 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인사이트 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping
+    ResponseEntity<InsightResponseDto.InsightRes> createInsight(
+            @RequestBody InsightRequestDto.CreateDto request
+    );
+
+    @Operation(summary = "인사이트 수정", description = "기존 인사이트 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인사이트 수정 성공"),
+            @ApiResponse(responseCode = "404", description = "인사이트를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PutMapping("/{insightId}")
+    ResponseEntity<InsightResponseDto.InsightRes> updateInsight(
+            @Parameter(description = "수정할 인사이트 ID") @PathVariable Long insightId,
+            @RequestBody InsightRequestDto.UpdateDto request
+    );
+
+    @Operation(summary = "인사이트 삭제", description = "특정 ID의 인사이트를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "인사이트 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "인사이트를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @DeleteMapping("/{insightId}")
+    ResponseEntity<Void> deleteInsight(
+            @Parameter(description = "삭제할 인사이트 ID") @PathVariable Long insightId
+    );
+
+    @Operation(summary = "특정 인사이트 조회", description = "ID를 이용해 특정 인사이트 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인사이트 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "인사이트를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/{insightId}")
+    ResponseEntity<InsightResponseDto.InsightRes> getInsightById(
+            @Parameter(description = "조회할 인사이트 ID") @PathVariable Long insightId
+    );
 }

--- a/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
@@ -1,7 +1,26 @@
 package zoo.insightnote.domain.insight.controller;
 
-import org.springframework.stereotype.Controller;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import zoo.insightnote.domain.insight.dto.InsightRequestDto;
+import zoo.insightnote.domain.insight.dto.InsightResponseDto;
+import zoo.insightnote.domain.insight.service.InsightService;
 
-@Controller
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/insights")
 public class InsightControllerImpl implements InsightController{
+
+    private final InsightService insightService;
+
+    @PostMapping
+    public ResponseEntity<InsightResponseDto> createInsight(@RequestBody InsightRequestDto.CreateDto request) {
+        InsightResponseDto insight = insightService.createInsight(request);
+        return ResponseEntity.ok(insight);
+    }
+
 }

--- a/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
@@ -2,10 +2,7 @@ package zoo.insightnote.domain.insight.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import zoo.insightnote.domain.insight.dto.InsightRequestDto;
 import zoo.insightnote.domain.insight.dto.InsightResponseDto;
 import zoo.insightnote.domain.insight.service.InsightService;
@@ -21,6 +18,14 @@ public class InsightControllerImpl implements InsightController{
     public ResponseEntity<InsightResponseDto> createInsight(@RequestBody InsightRequestDto.CreateDto request) {
         InsightResponseDto insight = insightService.createInsight(request);
         return ResponseEntity.ok(insight);
+    }
+
+    @PutMapping("/{insightId}")
+    public ResponseEntity<InsightResponseDto> updateInsight(
+            @PathVariable Long insightId,
+            @RequestBody InsightRequestDto.UpdateDto request) {
+        InsightResponseDto updatedInsight = insightService.updateInsight(insightId, request);
+        return ResponseEntity.ok(updatedInsight);
     }
 
 }

--- a/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
@@ -14,24 +14,34 @@ public class InsightControllerImpl implements InsightController{
 
     private final InsightService insightService;
 
+    @Override
     @PostMapping
-    public ResponseEntity<InsightResponseDto> createInsight(@RequestBody InsightRequestDto.CreateDto request) {
-        InsightResponseDto insight = insightService.createInsight(request);
+    public ResponseEntity<InsightResponseDto.InsightRes> createInsight(
+            @RequestBody InsightRequestDto.CreateDto request) {
+        InsightResponseDto.InsightRes insight = insightService.createInsight(request);
         return ResponseEntity.ok(insight);
     }
 
+    @Override
     @PutMapping("/{insightId}")
-    public ResponseEntity<InsightResponseDto> updateInsight(
+    public ResponseEntity<InsightResponseDto.InsightRes> updateInsight(
             @PathVariable Long insightId,
             @RequestBody InsightRequestDto.UpdateDto request) {
-        InsightResponseDto updatedInsight = insightService.updateInsight(insightId, request);
+        InsightResponseDto.InsightRes updatedInsight = insightService.updateInsight(insightId, request);
         return ResponseEntity.ok(updatedInsight);
     }
 
+    @Override
     @DeleteMapping("/{insightId}")
     public ResponseEntity<Void> deleteInsight(@PathVariable Long insightId) {
         insightService.deleteInsight(insightId);
         return ResponseEntity.noContent().build();
     }
 
+    @Override
+    @GetMapping("/{insightId}")
+    public ResponseEntity<InsightResponseDto.InsightRes> getInsightById(@PathVariable Long insightId) {
+        InsightResponseDto.InsightRes insight = insightService.getInsightById(insightId);
+        return ResponseEntity.ok(insight);
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
@@ -28,4 +28,10 @@ public class InsightControllerImpl implements InsightController{
         return ResponseEntity.ok(updatedInsight);
     }
 
+    @DeleteMapping("/{insightId}")
+    public ResponseEntity<Void> deleteInsight(@PathVariable Long insightId) {
+        insightService.deleteInsight(insightId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/zoo/insightnote/domain/insight/dto/InsightRequestDto.java
+++ b/src/main/java/zoo/insightnote/domain/insight/dto/InsightRequestDto.java
@@ -22,5 +22,6 @@ public class InsightRequestDto {
     public static class UpdateDto {
         private String memo;
         private Boolean isPublic;
+        private List<ImageRequest.UploadImage> images;
     }
 }

--- a/src/main/java/zoo/insightnote/domain/insight/dto/InsightRequestDto.java
+++ b/src/main/java/zoo/insightnote/domain/insight/dto/InsightRequestDto.java
@@ -1,0 +1,26 @@
+package zoo.insightnote.domain.insight.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import zoo.insightnote.domain.image.dto.ImageRequest;
+
+import java.util.List;
+
+public class InsightRequestDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class CreateDto {
+        private Long sessionId;
+        private String memo;
+        private Boolean isPublic;
+        private List<ImageRequest.UploadImage> images;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class UpdateDto {
+        private String memo;
+        private Boolean isPublic;
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
@@ -1,0 +1,19 @@
+package zoo.insightnote.domain.insight.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class InsightResponseDto {
+
+    private Long id;
+    private Long sessionId;
+    private String memo;
+    private Boolean isPublic;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
@@ -5,15 +5,17 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-@Getter
-@AllArgsConstructor
 public class InsightResponseDto {
 
-    private Long id;
-    private Long sessionId;
-    private String memo;
-    private Boolean isPublic;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    @Getter
+    @AllArgsConstructor
+    public static class InsightRes {
+        private Long id;
+        private Long sessionId;
+        private String memo;
+        private Boolean isPublic;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
 
 }

--- a/src/main/java/zoo/insightnote/domain/insight/entity/Insight.java
+++ b/src/main/java/zoo/insightnote/domain/insight/entity/Insight.java
@@ -34,4 +34,18 @@ public class Insight extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String memo;
 
+    @Column(nullable = false)
+    private Boolean isPublic;
+
+    public static Insight create(Session session, String memo, Boolean isPublic) {
+        return Insight.builder()
+                .session(session)
+                .memo(memo)
+                .isPublic(isPublic != null ? isPublic : true)
+                .build();
+    }
+
+    public void changeIsPublic(boolean isPublic) {
+        this.isPublic = isPublic;
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/insight/entity/Insight.java
+++ b/src/main/java/zoo/insightnote/domain/insight/entity/Insight.java
@@ -45,7 +45,13 @@ public class Insight extends BaseTimeEntity {
                 .build();
     }
 
-    public void changeIsPublic(boolean isPublic) {
-        this.isPublic = isPublic;
+    public void updateIfChanged(String newMemo, Boolean newIsPublic) {
+        if (newMemo != null && !newMemo.equals(this.memo)) {
+            this.memo = newMemo;
+        }
+        if (newIsPublic != null && !newIsPublic.equals(this.isPublic)) {
+            this.isPublic = newIsPublic;
+        }
+
     }
 }

--- a/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
+++ b/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
@@ -1,0 +1,24 @@
+package zoo.insightnote.domain.insight.mapper;
+
+import zoo.insightnote.domain.insight.dto.InsightRequestDto;
+import zoo.insightnote.domain.insight.dto.InsightResponseDto;
+import zoo.insightnote.domain.insight.entity.Insight;
+import zoo.insightnote.domain.session.entity.Session;
+
+public class InsightMapper {
+
+    public static Insight toEntity(InsightRequestDto.CreateDto request, Session session) {
+        return Insight.create(session, request.getMemo(), request.getIsPublic());
+    }
+
+    public static InsightResponseDto toResponse(Insight insight) {
+        return new InsightResponseDto(
+                insight.getId(),
+                insight.getSession().getId(),
+                insight.getMemo(),
+                insight.getIsPublic(),
+                insight.getCreateAt(),
+                insight.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
+++ b/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
@@ -11,8 +11,8 @@ public class InsightMapper {
         return Insight.create(session, request.getMemo(), request.getIsPublic());
     }
 
-    public static InsightResponseDto toResponse(Insight insight) {
-        return new InsightResponseDto(
+    public static InsightResponseDto.InsightRes toResponse(Insight insight) {
+        return new InsightResponseDto.InsightRes(
                 insight.getId(),
                 insight.getSession().getId(),
                 insight.getMemo(),

--- a/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
+++ b/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
@@ -24,7 +24,7 @@ public class InsightService {
     private final ImageService imageService;
 
     @Transactional
-    public InsightResponseDto createInsight(InsightRequestDto.CreateDto request) {
+    public InsightResponseDto.InsightRes createInsight(InsightRequestDto.CreateDto request) {
         Session session = sessionRepository.findById(request.getSessionId())
                 .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));
 
@@ -37,7 +37,7 @@ public class InsightService {
     }
 
     @Transactional
-    public InsightResponseDto updateInsight(Long insightId, InsightRequestDto.UpdateDto request) {
+    public InsightResponseDto.InsightRes updateInsight(Long insightId, InsightRequestDto.UpdateDto request) {
         Insight insight = insightRepository.findById(insightId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INSIGHT_NOT_FOUND));
 
@@ -57,5 +57,12 @@ public class InsightService {
         Insight insight = insightRepository.findById(insightId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INSIGHT_NOT_FOUND));
         insightRepository.delete(insight);
+    }
+
+    @Transactional(readOnly = true)
+    public InsightResponseDto.InsightRes getInsightById(Long insightId) {
+        Insight insight = insightRepository.findById(insightId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INSIGHT_NOT_FOUND));
+        return InsightMapper.toResponse(insight);
     }
 }

--- a/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
+++ b/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
@@ -3,6 +3,7 @@ package zoo.insightnote.domain.insight.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import zoo.insightnote.domain.image.dto.ImageRequest;
 import zoo.insightnote.domain.image.entity.EntityType;
 import zoo.insightnote.domain.image.service.ImageService;
 import zoo.insightnote.domain.insight.dto.InsightRequestDto;
@@ -33,5 +34,21 @@ public class InsightService {
         imageService.saveImages(savedInsight.getId(), EntityType.INSIGHT, request.getImages());
 
         return InsightMapper.toResponse(savedInsight);
+    }
+
+    @Transactional
+    public InsightResponseDto updateInsight(Long insightId, InsightRequestDto.UpdateDto request) {
+        Insight insight = insightRepository.findById(insightId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INSIGHT_NOT_FOUND));
+
+        insight.updateIfChanged(request.getMemo(), request.getIsPublic());
+
+        imageService.updateImages(new ImageRequest.UploadImages(
+                insight.getId(),
+                EntityType.INSIGHT,
+                request.getImages()
+        ));
+
+        return InsightMapper.toResponse(insight);
     }
 }

--- a/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
+++ b/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
@@ -51,4 +51,11 @@ public class InsightService {
 
         return InsightMapper.toResponse(insight);
     }
+
+    @Transactional
+    public void deleteInsight(Long insightId) {
+        Insight insight = insightRepository.findById(insightId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INSIGHT_NOT_FOUND));
+        insightRepository.delete(insight);
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/session/entity/Session.java
+++ b/src/main/java/zoo/insightnote/domain/session/entity/Session.java
@@ -59,6 +59,23 @@ public class Session {
 
     private String location;
 
+    public static Session create(SessionRequest.Create request, Event event, Speaker speaker) {
+        return Session.builder()
+                .event(event)
+                .speaker(speaker)
+                .eventDay(request.eventDay())
+                .name(request.name())
+                .shortDescription(request.shortDescription())
+                .longDescription(request.longDescription())
+                .maxCapacity(request.maxCapacity())
+                .startTime(request.startTime())
+                .endTime(request.endTime())
+                .status(request.status())
+                .videoLink(request.videoLink())
+                .location(request.location())
+                .build();
+    }
+
     public void update(SessionRequest.Update request) {
         if (request.name() != null) this.name = request.name();
         if (request.shortDescription() != null) this.shortDescription = request.shortDescription();

--- a/src/main/java/zoo/insightnote/domain/session/mapper/SessionMapper.java
+++ b/src/main/java/zoo/insightnote/domain/session/mapper/SessionMapper.java
@@ -9,20 +9,7 @@ import zoo.insightnote.domain.speaker.entity.Speaker;
 public class SessionMapper {
 
     public static Session toEntity(SessionRequest.Create request, Event event, Speaker speaker) {
-        return Session.builder()
-                .event(event)
-                .speaker(speaker)
-                .eventDay(request.eventDay())
-                .name(request.name())
-                .shortDescription(request.shortDescription())
-                .longDescription(request.longDescription())
-                .maxCapacity(request.maxCapacity())
-                .startTime(request.startTime())
-                .endTime(request.endTime())
-                .status(request.status())
-                .videoLink(request.videoLink())
-                .location(request.location())
-                .build();
+        return Session.create(request, event, speaker);
     }
 
     // Session엔티티 객체를 dto에서 정의한 record르 변환

--- a/src/main/java/zoo/insightnote/global/exception/ErrorCode.java
+++ b/src/main/java/zoo/insightnote/global/exception/ErrorCode.java
@@ -12,6 +12,9 @@ public enum ErrorCode {
     // 세션
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 세션을 찾을 수 없습니다."),
 
+    // 인사이트 노트
+    INSIGHT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 인사이트를 찾을 수 없습니다."),
+
     // 연사
     SPEAKER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 연사가 존재하지 않습니다."),
 


### PR DESCRIPTION
## Summary

>- #17 
- close #17 
insightNote CRUD api 구현 

## Tasks

- 인사이트 노트의 기본 CRUD 구현
- 스웨거 테스트 

## To Reviewer

- 테스트 코드경우 인사이트 노트와 , 세션 모두 기능이 변경될것 같아서 그때마다 테스트도 수정할 것 같아서 후순위로 두었습니다 
- dto 방법을 inner class 방식으로 변경했습니다 
 -  팀원 모두가 적용을 해야하는 방식이라 제가 생각한 부분을 아래에 적었습니다 , 혹시나 이해가 안가거나 잘못된 부분이 있다고 생각되면 언제든 말씀 부탁드립니다 

InsightRequestDto 파일 
-  class InsightRequestDto
     - public static class CreateDto
     - public static class UpdateDto
이렇게 dto class 를 각각 설정 

InsightResponseDto 파일
- class InsightResponseDto
  - public static class InsightRes 
 이렇게  InsightRes  네이밍을 지어서 
예를 들면 
기본적인 응답 DTO : InsightRes 
목록 조회용 DTO :  InsightListRes
상세 조회 DTO : InsightDetailRes 
이런 방향을 생각하고 있습니다 
 

## Screenshot

