### PR TITLE
[#4] 소셜 로그인 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,14 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // OAuth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/zoo/insightnote/domain/user/dto/CustomOAuth2User.java
+++ b/src/main/java/zoo/insightnote/domain/user/dto/CustomOAuth2User.java
@@ -1,0 +1,40 @@
+package zoo.insightnote.domain.user.dto;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    private final UserDto userDto;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return userDto.getRole();
+            }
+        });
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+        return userDto.getName();
+    }
+
+    public String getUsername() {
+        return userDto.getUsername();
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/user/dto/GoogleResponse.java
+++ b/src/main/java/zoo/insightnote/domain/user/dto/GoogleResponse.java
@@ -1,0 +1,32 @@
+package zoo.insightnote.domain.user.dto;
+
+import java.util.Map;
+
+public class GoogleResponse implements OAuth2Response{
+
+    private final Map<String, Object> attributes;
+
+    public GoogleResponse(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get("name").toString();
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/user/dto/KakaoResponse.java
+++ b/src/main/java/zoo/insightnote/domain/user/dto/KakaoResponse.java
@@ -1,0 +1,36 @@
+package zoo.insightnote.domain.user.dto;
+
+import java.util.Map;
+
+public class KakaoResponse implements OAuth2Response {
+
+    private final Map<String, Object> attributes;
+    private final Map<String, Object> kakaoAccount;
+    private final Map<String, Object> profile;
+
+    public KakaoResponse(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.profile = (Map<String, Object>) kakaoAccount.get("profile");
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return kakaoAccount.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return profile.get("nickname").toString();
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/user/dto/OAuth2Response.java
+++ b/src/main/java/zoo/insightnote/domain/user/dto/OAuth2Response.java
@@ -1,0 +1,8 @@
+package zoo.insightnote.domain.user.dto;
+
+public interface OAuth2Response {
+    String getProvider();
+    String getProviderId();
+    String getEmail();
+    String getName();
+}

--- a/src/main/java/zoo/insightnote/domain/user/dto/UserDto.java
+++ b/src/main/java/zoo/insightnote/domain/user/dto/UserDto.java
@@ -10,4 +10,5 @@ public class UserDto {
     private String name;
     private String username;
     private String role;
+    private String email;
 }

--- a/src/main/java/zoo/insightnote/domain/user/dto/UserDto.java
+++ b/src/main/java/zoo/insightnote/domain/user/dto/UserDto.java
@@ -1,0 +1,13 @@
+package zoo.insightnote.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UserDto {
+
+    private String role;
+    private String name;
+    private String username;
+}

--- a/src/main/java/zoo/insightnote/domain/user/dto/UserDto.java
+++ b/src/main/java/zoo/insightnote/domain/user/dto/UserDto.java
@@ -2,19 +2,12 @@ package zoo.insightnote.domain.user.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import zoo.insightnote.domain.user.entity.Role;
 
-@Builder
 @Getter
+@Builder
 public class UserDto {
 
     private String name;
     private String username;
     private String role;
-
-    @Builder
-    public UserDto(String username, String Role) {
-        this.username = username;
-        this.role = Role;
-    }
 }

--- a/src/main/java/zoo/insightnote/domain/user/dto/UserDto.java
+++ b/src/main/java/zoo/insightnote/domain/user/dto/UserDto.java
@@ -2,12 +2,13 @@ package zoo.insightnote.domain.user.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import zoo.insightnote.domain.user.entity.Role;
 
 @Builder
 @Getter
 public class UserDto {
 
-    private String role;
     private String name;
     private String username;
+    private String role;
 }

--- a/src/main/java/zoo/insightnote/domain/user/dto/UserDto.java
+++ b/src/main/java/zoo/insightnote/domain/user/dto/UserDto.java
@@ -11,4 +11,10 @@ public class UserDto {
     private String name;
     private String username;
     private String role;
+
+    @Builder
+    public UserDto(String username, String Role) {
+        this.username = username;
+        this.role = Role;
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/user/entity/AuthProvider.java
+++ b/src/main/java/zoo/insightnote/domain/user/entity/AuthProvider.java
@@ -1,0 +1,7 @@
+package zoo.insightnote.domain.user.entity;
+
+public enum AuthProvider {
+    KAKAO,
+    GOOGLE,
+    NONE // 비회원 (Guest)
+}

--- a/src/main/java/zoo/insightnote/domain/user/entity/Role.java
+++ b/src/main/java/zoo/insightnote/domain/user/entity/Role.java
@@ -1,5 +1,7 @@
 package zoo.insightnote.domain.user.entity;
 
 public enum Role {
-    USER, ADMIN
+    USER,
+    GUEST,
+    ADMIN
 }

--- a/src/main/java/zoo/insightnote/domain/user/entity/User.java
+++ b/src/main/java/zoo/insightnote/domain/user/entity/User.java
@@ -6,13 +6,19 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class User {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String username;
 
     private String name;
 
@@ -33,4 +39,17 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     private AuthProvider provider;
+
+    @Builder
+    public User(String username, String name, String email, Role role) {
+        this.username = username;
+        this.name = name;
+        this.email = email;
+        this.role = role;
+    }
+
+    public void update(String email, String name) {
+        this.email = email;
+        this.name = name;
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/user/entity/User.java
+++ b/src/main/java/zoo/insightnote/domain/user/entity/User.java
@@ -31,4 +31,6 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Enumerated(EnumType.STRING)
+    private AuthProvider provider;
 }

--- a/src/main/java/zoo/insightnote/domain/user/repository/UserRepository.java
+++ b/src/main/java/zoo/insightnote/domain/user/repository/UserRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import zoo.insightnote.domain.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    User findByUsername(String username);
 }

--- a/src/main/java/zoo/insightnote/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/zoo/insightnote/domain/user/service/CustomOAuth2UserService.java
@@ -5,9 +5,11 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import zoo.insightnote.domain.user.dto.CustomOAuth2User;
 import zoo.insightnote.domain.user.dto.GoogleResponse;
 import zoo.insightnote.domain.user.dto.KakaoResponse;
 import zoo.insightnote.domain.user.dto.OAuth2Response;
+import zoo.insightnote.domain.user.dto.UserDto;
 
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
@@ -20,7 +22,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         OAuth2Response oAuth2Response =  getOAuth2User(registrationId, oAuth2User);
 
-        // 추후 개발
+        String username = oAuth2Response.getProvider() + " " + oAuth2Response.getProviderId();
+
+        UserDto userDto = UserDto.builder()
+                .username(username)
+                .name(oAuth2Response.getName())
+                .role("ROLE_USER")
+                .build();
+
+        return new CustomOAuth2User(userDto);
     }
 
     private static OAuth2Response getOAuth2User(String registrationId, OAuth2User oAuth2User) {

--- a/src/main/java/zoo/insightnote/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/zoo/insightnote/domain/user/service/CustomOAuth2UserService.java
@@ -8,6 +8,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import zoo.insightnote.domain.user.dto.CustomOAuth2User;
 import zoo.insightnote.domain.user.dto.GoogleResponse;
 import zoo.insightnote.domain.user.dto.KakaoResponse;
@@ -18,6 +19,7 @@ import zoo.insightnote.domain.user.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
@@ -40,6 +42,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             User user = User.builder()
                     .username(username)
                     .name(oAuth2Response.getName())
+                    .email(oAuth2Response.getEmail())
                     .role(USER)
                     .build();
             userRepository.save(user);
@@ -47,6 +50,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             UserDto userDto = UserDto.builder()
                     .username(username)
                     .name(user.getName())
+                    .email(user.getEmail())
                     .role("ROLE_USER")
                     .build();
             return new CustomOAuth2User(userDto);
@@ -57,6 +61,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         UserDto userDto = UserDto.builder()
                 .username(username)
                 .name(existData.getName())
+                .email(existData.getEmail())
                 .role("ROLE_USER")
                 .build();
         return new CustomOAuth2User(userDto);

--- a/src/main/java/zoo/insightnote/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/zoo/insightnote/domain/user/service/CustomOAuth2UserService.java
@@ -1,0 +1,35 @@
+package zoo.insightnote.domain.user.service;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import zoo.insightnote.domain.user.dto.GoogleResponse;
+import zoo.insightnote.domain.user.dto.KakaoResponse;
+import zoo.insightnote.domain.user.dto.OAuth2Response;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        System.out.println(oAuth2User);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2Response oAuth2Response =  getOAuth2User(registrationId, oAuth2User);
+
+        // 추후 개발
+    }
+
+    private static OAuth2Response getOAuth2User(String registrationId, OAuth2User oAuth2User) {
+        if (registrationId.equals("kakao")){
+            return new KakaoResponse(oAuth2User.getAttributes());
+        }
+        if (registrationId.equals("google")){
+            return new GoogleResponse(oAuth2User.getAttributes());
+        }
+        return null;
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/zoo/insightnote/domain/user/service/CustomOAuth2UserService.java
@@ -1,5 +1,8 @@
 package zoo.insightnote.domain.user.service;
 
+import static zoo.insightnote.domain.user.entity.Role.*;
+
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -10,9 +13,14 @@ import zoo.insightnote.domain.user.dto.GoogleResponse;
 import zoo.insightnote.domain.user.dto.KakaoResponse;
 import zoo.insightnote.domain.user.dto.OAuth2Response;
 import zoo.insightnote.domain.user.dto.UserDto;
+import zoo.insightnote.domain.user.entity.User;
+import zoo.insightnote.domain.user.repository.UserRepository;
 
 @Service
+@RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -20,16 +28,37 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         System.out.println(oAuth2User);
 
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        OAuth2Response oAuth2Response =  getOAuth2User(registrationId, oAuth2User);
+        OAuth2Response oAuth2Response = getOAuth2User(registrationId, oAuth2User);
 
         String username = oAuth2Response.getProvider() + " " + oAuth2Response.getProviderId();
+        User existData = userRepository.findByUsername(username);
+        return saveOAuth2User(existData, username, oAuth2Response);
+    }
+
+    private CustomOAuth2User saveOAuth2User(User existData, String username, OAuth2Response oAuth2Response) {
+        if(existData == null){
+            User user = User.builder()
+                    .username(username)
+                    .name(oAuth2Response.getName())
+                    .role(USER)
+                    .build();
+            userRepository.save(user);
+
+            UserDto userDto = UserDto.builder()
+                    .username(username)
+                    .name(user.getName())
+                    .role("ROLE_USER")
+                    .build();
+            return new CustomOAuth2User(userDto);
+        }
+
+        existData.update(oAuth2Response.getEmail(), oAuth2Response.getName());
 
         UserDto userDto = UserDto.builder()
                 .username(username)
-                .name(oAuth2Response.getName())
+                .name(existData.getName())
                 .role("ROLE_USER")
                 .build();
-
         return new CustomOAuth2User(userDto);
     }
 

--- a/src/main/java/zoo/insightnote/global/config/CorsMvcConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/CorsMvcConfig.java
@@ -1,0 +1,20 @@
+package zoo.insightnote.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+    @Value("${FRONT_URL}")
+    private String frontUrl;
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+        corsRegistry.addMapping("/**")
+                .exposedHeaders("Set-Cookie")
+                .allowedOrigins("frontUrl");
+    }
+}

--- a/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
@@ -1,8 +1,11 @@
 package zoo.insightnote.global.config;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -11,6 +14,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import zoo.insightnote.domain.user.service.CustomOAuth2UserService;
 import zoo.insightnote.global.jwt.JWTFilter;
 import zoo.insightnote.global.jwt.JWTUtil;
@@ -21,12 +26,37 @@ import zoo.insightnote.global.oauth2.CustomSuccessHandler;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    @Value("${FRONT_URL}")
+    private String frontUrl;
+
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomSuccessHandler customSuccessHandler;
     private final JWTUtil jwtUtil;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        // CORS 설정
+        http
+                .cors(corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
+
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+
+                        CorsConfiguration configuration = new CorsConfiguration();
+
+                        configuration.setAllowedOrigins(Collections.singletonList(frontUrl));
+                        configuration.setAllowedMethods(Collections.singletonList("*"));
+                        configuration.setAllowCredentials(true);
+                        configuration.setAllowedHeaders(Collections.singletonList("*"));
+                        configuration.setMaxAge(3600L);
+
+                        configuration.setExposedHeaders(Collections.singletonList("Set-Cookie"));
+                        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+
+                        return configuration;
+                    }
+                }));
 
         //csrf disable
         http

--- a/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -72,7 +73,7 @@ public class SecurityConfig {
 
         //JWTFilter 추가
         http
-                .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterAfter(new JWTFilter(jwtUtil), OAuth2LoginAuthenticationFilter.class);
 
         //oauth2
         http

--- a/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
@@ -10,7 +10,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import zoo.insightnote.domain.user.service.CustomOAuth2UserService;
+import zoo.insightnote.global.jwt.JWTFilter;
 import zoo.insightnote.global.jwt.JWTUtil;
 import zoo.insightnote.global.oauth2.CustomSuccessHandler;
 
@@ -37,6 +39,10 @@ public class SecurityConfig {
         //HTTP Basic 인증 방식 disable
         http
                 .httpBasic((auth) -> auth.disable());
+
+        //JWTFilter 추가
+        http
+                .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
         //oauth2
         http

--- a/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import zoo.insightnote.domain.user.service.CustomOAuth2UserService;
+import zoo.insightnote.global.jwt.JWTUtil;
+import zoo.insightnote.global.oauth2.CustomSuccessHandler;
 
 @Configuration
 @EnableWebSecurity
@@ -18,6 +20,8 @@ import zoo.insightnote.domain.user.service.CustomOAuth2UserService;
 public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomSuccessHandler customSuccessHandler;
+    private final JWTUtil jwtUtil;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -38,7 +42,8 @@ public class SecurityConfig {
         http
                 .oauth2Login((oauth2) -> oauth2
                         .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
-                                .userService(customOAuth2UserService)));
+                                .userService(customOAuth2UserService))
+                        .successHandler(customSuccessHandler));
 
         //경로별 인가 작업
         http

--- a/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
@@ -1,0 +1,47 @@
+package zoo.insightnote.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        //csrf disable
+        http
+                .csrf((auth) -> auth.disable());
+
+        //From 로그인 방식 disable
+        http
+                .formLogin((auth) -> auth.disable());
+
+        //HTTP Basic 인증 방식 disable
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        //oauth2
+        http
+                .oauth2Login(Customizer.withDefaults());
+
+        //경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/").permitAll()
+                        .anyRequest().authenticated());
+
+        //세션 설정 : STATELESS
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package zoo.insightnote.global.config;
 
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -7,10 +10,14 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import zoo.insightnote.domain.user.service.CustomOAuth2UserService;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -29,7 +36,9 @@ public class SecurityConfig {
 
         //oauth2
         http
-                .oauth2Login(Customizer.withDefaults());
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService)));
 
         //경로별 인가 작업
         http

--- a/src/main/java/zoo/insightnote/global/jwt/JWTFilter.java
+++ b/src/main/java/zoo/insightnote/global/jwt/JWTFilter.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import zoo.insightnote.domain.user.dto.CustomOAuth2User;
@@ -55,14 +56,14 @@ public class JWTFilter extends OncePerRequestFilter {
     private void checkToken(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain,
                            String token) throws IOException, ServletException {
         if (jwtUtil.isExpired(token)) {
-            throw new IllegalArgumentException("token expired");
+            throw new AuthenticationException("token expired") {};
         }
     }
 
     private void checkAuthorization(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain,
                                   String authorization) throws IOException, ServletException {
         if (authorization == null) {
-            throw new IllegalArgumentException("token null");
+            throw new AuthenticationException("token null") {};
         }
     }
 }

--- a/src/main/java/zoo/insightnote/global/jwt/JWTFilter.java
+++ b/src/main/java/zoo/insightnote/global/jwt/JWTFilter.java
@@ -1,0 +1,70 @@
+package zoo.insightnote.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import zoo.insightnote.domain.user.dto.CustomOAuth2User;
+import zoo.insightnote.domain.user.dto.UserDto;
+
+@RequiredArgsConstructor
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String authorization = getAuthorization(request);
+        checkAuthorization(request, response, filterChain, authorization);
+
+        String token = authorization;
+        checkToken(request, response, filterChain, token);
+
+        UserDto userDto = UserDto.builder()
+                .username(jwtUtil.getUsername(token))
+                .role(jwtUtil.getRole(token))
+                .build();
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
+
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null,
+                customOAuth2User.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private static String getAuthorization(HttpServletRequest request) {
+        String authorization = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("Authorization")) {
+                authorization = cookie.getValue();
+            }
+        }
+        return authorization;
+    }
+
+    private void checkToken(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain,
+                           String token) throws IOException, ServletException {
+        if (jwtUtil.isExpired(token)) {
+            filterChain.doFilter(request, response);
+            throw new IllegalArgumentException("token expired");
+        }
+    }
+
+    private static void checkAuthorization(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain,
+                                  String authorization) throws IOException, ServletException {
+        if (authorization == null) {
+            filterChain.doFilter(request, response);
+            throw new IllegalArgumentException("token null");
+        }
+    }
+}

--- a/src/main/java/zoo/insightnote/global/jwt/JWTFilter.java
+++ b/src/main/java/zoo/insightnote/global/jwt/JWTFilter.java
@@ -41,7 +41,7 @@ public class JWTFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private static String getAuthorization(HttpServletRequest request) {
+    private String getAuthorization(HttpServletRequest request) {
         String authorization = null;
         Cookie[] cookies = request.getCookies();
         for (Cookie cookie : cookies) {
@@ -55,15 +55,13 @@ public class JWTFilter extends OncePerRequestFilter {
     private void checkToken(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain,
                            String token) throws IOException, ServletException {
         if (jwtUtil.isExpired(token)) {
-            filterChain.doFilter(request, response);
             throw new IllegalArgumentException("token expired");
         }
     }
 
-    private static void checkAuthorization(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain,
+    private void checkAuthorization(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain,
                                   String authorization) throws IOException, ServletException {
         if (authorization == null) {
-            filterChain.doFilter(request, response);
             throw new IllegalArgumentException("token null");
         }
     }

--- a/src/main/java/zoo/insightnote/global/jwt/JWTUtil.java
+++ b/src/main/java/zoo/insightnote/global/jwt/JWTUtil.java
@@ -1,0 +1,45 @@
+package zoo.insightnote.global.jwt;
+
+import io.jsonwebtoken.Jwts;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JWTUtil {
+
+    private SecretKey secretKey;
+
+    public JWTUtil(@Value("${jwt.secret}") String secret) {
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+                .get("username", String.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+                .get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration()
+                .before(new Date());
+    }
+
+    public String createJwt(String username, String role, Long expiredMs) {
+        return Jwts.builder()
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/zoo/insightnote/global/jwt/JWTUtil.java
+++ b/src/main/java/zoo/insightnote/global/jwt/JWTUtil.java
@@ -13,7 +13,7 @@ public class JWTUtil {
 
     private SecretKey secretKey;
 
-    public JWTUtil(@Value("${jwt.secret}") String secret) {
+    public JWTUtil(@Value("${JWT_SECRET}") String secret) {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
                 Jwts.SIG.HS256.key().build().getAlgorithm());
     }

--- a/src/main/java/zoo/insightnote/global/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/zoo/insightnote/global/oauth2/CustomSuccessHandler.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -18,6 +19,9 @@ import zoo.insightnote.global.jwt.JWTUtil;
 @Component
 @RequiredArgsConstructor
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Value("${FRONT_URL}")
+    private String frontUrl;
 
     private final JWTUtil jwtUtil;
 
@@ -33,7 +37,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String token = jwtUtil.createJwt(username, role, 60*60*60L);
 
         response.addCookie(createCookie("Authorization", token));
-        response.sendRedirect("http://localhost:3000/"); // 추후 프론트 배포 서버로 변경 해야됨.
+        response.sendRedirect(frontUrl); // 추후 프론트 배포 서버로 변경 해야됨.
     }
 
     private Cookie createCookie(String key, String value) {

--- a/src/main/java/zoo/insightnote/global/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/zoo/insightnote/global/oauth2/CustomSuccessHandler.java
@@ -1,0 +1,47 @@
+package zoo.insightnote.global.oauth2;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import zoo.insightnote.domain.user.dto.CustomOAuth2User;
+import zoo.insightnote.global.jwt.JWTUtil;
+
+@Component
+@RequiredArgsConstructor
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JWTUtil jwtUtil;
+
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+        String username = customUserDetails.getUsername();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+        String token = jwtUtil.createJwt(username, role, 60*60*60L);
+
+        response.addCookie(createCookie("Authorization", token));
+        response.sendRedirect("http://localhost:3000/"); // 추후 프론트 배포 서버로 변경 해야됨.
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60*60*60);
+        //cookie.setSecure(true); // https를 사용하는 경우에 주석 해제
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        return cookie;
+    }
+}

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -22,6 +22,8 @@ spring:
             authorization-grant-type: authorization_code
             scope:
               - account_email
+              - profile_nickname
+              - profile_image
 
         provider:
           kakao:

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -1,0 +1,31 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-name: google
+            client-id: ${GOOGLE_CLIENT}
+            client-secret: ${GOOGLE_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/google
+            authorization-grant-type: authorization_code
+            scope:
+              - profile
+              - email
+
+          kakao:
+            client-name: kakao
+            client-id: ${KAKAO_CLIENT}
+            client-secret: ${KAKAO_SECRET}
+            client-authentication-method: client_secret_post
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            scope:
+              - account_email
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=InsightNote

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,43 @@
+spring:
+  application:
+    name: InsightNote
+
+  config:
+    import: optional:file:.env[.properties]
+  profiles:
+    include: oauth
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    show-sql: true
+    generate-ddl: true
+    hibernate:
+      ddl-auto: update
+      default_batch_fetch_size: 100
+
+  cloud:
+    aws:
+      s3:
+        credentials:
+          accessKey: ${AWS_S3_ACCESSKEY}
+          secretKey: ${AWS_S3_SECRETKEY}
+        bucket: ${AWS_S3_BUCKET}
+      region:
+        static: ${AWS_REGION}
+      stack:
+        auto: false
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+kakao:
+  api:
+    cid: TC0ONETIME
+    admin-key: ${KAKAO_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,9 @@ spring:
       host: localhost
       port: 6379
 
+  jwt:
+    secret: ${JWT_SECRET}
+
 kakao:
   api:
     cid: TC0ONETIME


### PR DESCRIPTION
## Summary

#4 
closed #4 

User의 소셜 로그인 구현 완료

## Tasks

- 소셜 로그인 구현(Kakao, Google)

## To Reviewer
![image](https://github.com/user-attachments/assets/a21d39a4-03a9-4125-a17c-b552b0fc37b2)
전체적인 동작 흐름을 나타낸 이미지입니다.
현재는 AccessToken 하나로만 로그인이 구현되어 있는 상태입니다. 추후 시간적 여유가 생긴다면 RefreshToken까지 도입하겠습니다.
그리고 현재 쿠키에 token을 저장하여 프론트로 전달합니다. 그 이유는 Oauth 로그인을 사용할 때 하이퍼링크 형식으로 소셜 로그인 페이지로 접속 하기 때문에 헤더에 토큰을 저장을 못한다고 합니다. 하지만 첫 발급 이후에는 헤더로 JWT를 이동 시킬 수 있습니다.
1. 로그인 성공 쿠키로 발급
2. 프론트의 특정 페이지로 리디렉션을 보냄
3. 프론트의 특정 페이지는 axios를 통해 쿠키를(credentials=true)를 가지고 다시 백엔드로 접근하여 헤더로 JWT를 받아옴
4. 헤더로 받아온 JWT를 로컬 스토리지등에 보관하여 사용
이렇게 헤더에 저장하여 사용할 수 있다고 합니다.
참고자료 : https://www.youtube.com/watch?v=n2HQkqhOvMo&t=24s

## Screenshot
![image](https://github.com/user-attachments/assets/a57d9b63-4358-473d-94cd-e533c1ebf050)

