### PR TITLE
[#16] 결제 내역, 예약 세션 저장

### DIFF
--- a/src/main/java/zoo/insightnote/domain/payment/controller/PaymentControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/payment/controller/PaymentControllerImpl.java
@@ -9,12 +9,14 @@ import zoo.insightnote.domain.payment.dto.request.PaymentRequestReadyDto;
 import zoo.insightnote.domain.payment.dto.response.KakaoPayApproveResponseDto;
 import zoo.insightnote.domain.payment.dto.response.KakaoPayReadyResponseDto;
 import zoo.insightnote.domain.payment.service.KakaoPayService;
+import zoo.insightnote.domain.payment.service.PaymentService;
 
 @RestController
 @RequestMapping("/api/v1/payment")
 @RequiredArgsConstructor
 public class PaymentControllerImpl implements PaymentController{
     private final KakaoPayService kakaoPayService;
+    private final PaymentService paymentService;
 
     // 주문 정보를 가지고 카카오페이 API에 결제 요청
     @PostMapping("/request")
@@ -31,6 +33,6 @@ public class PaymentControllerImpl implements PaymentController{
             @RequestParam(value = "pg_token") String pgToken
     ) {
         PaymentApproveRequestDto requestDto = new PaymentApproveRequestDto(orderId, userId, pgToken);
-        return kakaoPayService.approvePayment(requestDto);
+        return paymentService.approvePayment(requestDto);
     }
 }

--- a/src/main/java/zoo/insightnote/domain/payment/controller/PaymentControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/payment/controller/PaymentControllerImpl.java
@@ -21,7 +21,7 @@ public class PaymentControllerImpl implements PaymentController{
     // 주문 정보를 가지고 카카오페이 API에 결제 요청
     @PostMapping("/request")
     public ResponseEntity<KakaoPayReadyResponseDto> requestPayment(@RequestBody @Valid PaymentRequestReadyDto requestDto) {
-        ResponseEntity<KakaoPayReadyResponseDto> response = kakaoPayService.requestPayment(requestDto);
+        ResponseEntity<KakaoPayReadyResponseDto> response = kakaoPayService.requestKakaoPayment(requestDto);
         return response;
     }
 

--- a/src/main/java/zoo/insightnote/domain/payment/dto/etc/AmountDto.java
+++ b/src/main/java/zoo/insightnote/domain/payment/dto/etc/AmountDto.java
@@ -3,7 +3,9 @@ package zoo.insightnote.domain.payment.dto.etc;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Positive;
+import lombok.Getter;
 
+@Getter
 public class AmountDto {
     private int totalAmount;
 

--- a/src/main/java/zoo/insightnote/domain/payment/dto/etc/AmountDto.java
+++ b/src/main/java/zoo/insightnote/domain/payment/dto/etc/AmountDto.java
@@ -1,17 +1,25 @@
 package zoo.insightnote.domain.payment.dto.etc;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 
 @Getter
 public class AmountDto {
-    private int totalAmount;
+    @JsonProperty("total")
+    private int totalAmount;  // 전체 결제 금액
 
-    private int taxFreeAmount;
+    @JsonProperty("tax_free")
+    private int taxFreeAmount;  // 비과세 금액
 
-    private int vatAmount;
+    @JsonProperty("vat")
+    private int vatAmount;  // 부가세 금액
 
-    private int discountAmount;
+    @JsonProperty("point")
+    private int pointAmount;  // 사용한 포인트 금액
+
+    @JsonProperty("discount")
+    private int discountAmount;  // 할인 금액
+
+    @JsonProperty("green_deposit")
+    private int greenDepositAmount;  // 컵 보증금
 }

--- a/src/main/java/zoo/insightnote/domain/payment/dto/etc/CardInfoDto.java
+++ b/src/main/java/zoo/insightnote/domain/payment/dto/etc/CardInfoDto.java
@@ -1,33 +1,43 @@
 package zoo.insightnote.domain.payment.dto.etc;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 public class CardInfoDto {
-    private String purchase_corp;
+    @JsonProperty("kakaopay_purchase_corp")
+    private String kakaopayPurchaseCorp; // 카카오페이 매입사명
 
-    private String purchase_corp_code;
+    @JsonProperty("kakaopay_purchase_corp_code")
+    private String kakaopayPurchaseCorpCode; // 카카오페이 매입사 코드
 
-    private String issuer_corp;
+    @JsonProperty("kakaopay_issuer_corp")
+    private String kakaopayIssuerCorp; // 카카오페이 발급사명
 
-    private String issuer_corp_code;
+    @JsonProperty("kakaopay_issuer_corp_code")
+    private String kakaopayIssuerCorpCode; // 카카오페이 발급사 코드
 
-    private String bin;
+    @JsonProperty("bin")
+    private String bin; // 카드 BIN
 
-    private String card_type;
+    @JsonProperty("card_type")
+    private String cardType; // 카드 타입
 
-    private String install_month;
+    @JsonProperty("install_month")
+    private String installMonth; // 할부 개월 수
 
-    private String approved_id;
+    @JsonProperty("approved_id")
+    private String approvedId; // 카드사 승인번호
 
-    private String card_mid;
+    @JsonProperty("card_mid")
+    private String cardMid; // 카드사 가맹점 번호
 
-    private String interest_free_install;
+    @JsonProperty("interest_free_install")
+    private String interestFreeInstall; // 무이자할부 여부 (Y/N)
 
-    private String card_item_code;
+    @JsonProperty("installment_type")
+    private String installmentType; // 할부 유형
+
+    @JsonProperty("card_item_code")
+    private String cardItemCode; // 카드 상품 코드
 }

--- a/src/main/java/zoo/insightnote/domain/payment/dto/request/PaymentRequestReadyDto.java
+++ b/src/main/java/zoo/insightnote/domain/payment/dto/request/PaymentRequestReadyDto.java
@@ -16,9 +16,6 @@ import java.util.List;
 @AllArgsConstructor
 public class PaymentRequestReadyDto {
     @NotNull
-    private Long orderId;
-
-    @NotNull
     private Long userId;
 
     @NotBlank

--- a/src/main/java/zoo/insightnote/domain/payment/dto/request/PaymentRequestReadyDto.java
+++ b/src/main/java/zoo/insightnote/domain/payment/dto/request/PaymentRequestReadyDto.java
@@ -1,12 +1,15 @@
 package zoo.insightnote.domain.payment.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,4 +29,7 @@ public class PaymentRequestReadyDto {
 
     @Positive()
     private int quantity;
+
+    @NotEmpty
+    private List<Long> sessionIds;
 }

--- a/src/main/java/zoo/insightnote/domain/payment/entity/Payment.java
+++ b/src/main/java/zoo/insightnote/domain/payment/entity/Payment.java
@@ -10,6 +10,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import zoo.insightnote.domain.event.entity.Event;
 import zoo.insightnote.domain.user.entity.User;
@@ -17,6 +19,8 @@ import zoo.insightnote.global.entity.BaseTimeEntity;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Payment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/zoo/insightnote/domain/payment/service/KakaoPayService.java
+++ b/src/main/java/zoo/insightnote/domain/payment/service/KakaoPayService.java
@@ -29,7 +29,8 @@ public class KakaoPayService {
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
     private final RedisTemplate<String, String> redisTemplate;
-    private final long PAYMENT_EXPIRATION = 10 * 60; // 10분
+    private final long PAYMENT_TID_EXPIRATION = 10 * 60; // 10분
+    private final long PAYMENT_SESSION_KEYS_EXPIRATION = 5 * 60; // 5분
 
     @Value("${kakao.api.cid}")
     private String cid;
@@ -39,13 +40,30 @@ public class KakaoPayService {
 
 
     private void saveTidKey(Long orderId, String tid) {
-        String tidKey = "payment: " + orderId;
-        redisTemplate.opsForValue().set(tidKey, tid, PAYMENT_EXPIRATION, TimeUnit.SECONDS);
+        String tidKey = "payment:tid: " + orderId;
+        redisTemplate.opsForValue().set(tidKey, tid, PAYMENT_TID_EXPIRATION, TimeUnit.SECONDS);
     }
 
     public String getTidKey(Long orderId) {
-        String tidKey = "payment: " + orderId;
+        String tidKey = "payment:tid: " + orderId;
         return redisTemplate.opsForValue().get(tidKey);
+    }
+
+    private void saveSessionIds(Long orderId, List<Long> sessionsId) {
+        String sessionIdsKey = "payment:sessions: " + orderId;
+        try {
+            // ✅ JSON으로 변환하여 Redis에 저장
+            String jsonSessionIds = objectMapper.writeValueAsString(sessionsId);
+            redisTemplate.opsForValue().set(sessionIdsKey, jsonSessionIds, PAYMENT_SESSION_KEYS_EXPIRATION, TimeUnit.SECONDS);
+        } catch (JsonProcessingException e) {
+            log.error("❌ JSON 변환 오류 (sessionIds 저장 실패)", e);
+            throw new CustomException(ErrorCode.JSON_PROCESSING_ERROR);
+        }
+    }
+
+    public String getSessionIds(Long orderId) {
+        String sessionIdsKey = "payment:sessions: " + orderId;
+        return redisTemplate.opsForValue().get(sessionIdsKey);
     }
 
     // 결제 요청
@@ -64,6 +82,7 @@ public class KakaoPayService {
             log.info("✅ 카카오페이 결제 요청 성공");
 
             saveTidKey(requestDto.getOrderId(), tid);
+            saveSessionIds(requestDto.getOrderId(), requestDto.getSessionIds());
 
             return response;
         } catch (Exception e) {

--- a/src/main/java/zoo/insightnote/domain/payment/service/KakaoPayService.java
+++ b/src/main/java/zoo/insightnote/domain/payment/service/KakaoPayService.java
@@ -74,14 +74,7 @@ public class KakaoPayService {
 
     // 결제 승인 요청
     @Transactional
-    public ResponseEntity<KakaoPayApproveResponseDto> approvePayment(PaymentApproveRequestDto requestDto) {
-
-        // ✅ Redis에서 tid 조회
-        String tid = getTidKey(requestDto.getOrderId());
-        if (tid == null) {
-            log.error("❌ Redis에서 tid 조회 실패! (orderId={})", requestDto.getOrderId());
-                throw new CustomException(ErrorCode.PAYMENT_NOT_FOUND);
-        }
+    public ResponseEntity<KakaoPayApproveResponseDto> approvePayment(String tid, PaymentApproveRequestDto requestDto) {
 
         // ✅ 승인 요청용 HttpEntity 생성
         HttpEntity<String> paymentApproveHttpEntity = createPaymentApproveHttpEntity(requestDto, tid);
@@ -95,7 +88,6 @@ public class KakaoPayService {
                     KakaoPayApproveResponseDto.class
             );
 
-            log.info("✅ 카카오페이 결제 승인 성공");
             return response;
         } catch (Exception e) {
             log.error("❌ 카카오페이 결제 승인 실패", e);
@@ -158,6 +150,5 @@ public class KakaoPayService {
 
         return requestEntity;
     }
-
 }
 

--- a/src/main/java/zoo/insightnote/domain/payment/service/KakaoPayService.java
+++ b/src/main/java/zoo/insightnote/domain/payment/service/KakaoPayService.java
@@ -17,6 +17,7 @@ import zoo.insightnote.domain.payment.dto.response.KakaoPayReadyResponseDto;
 import zoo.insightnote.global.exception.CustomException;
 import zoo.insightnote.global.exception.ErrorCode;
 
+import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
@@ -106,7 +107,7 @@ public class KakaoPayService {
                     KakaoPayApproveResponseDto.class
             );
 
-            return response;
+            return response.getBody();
         } catch (Exception e) {
             log.error("❌ 카카오페이 결제 승인 실패", e);
             throw new CustomException(ErrorCode.KAKAO_PAY_APPROVE_FAILED);

--- a/src/main/java/zoo/insightnote/domain/payment/service/KakaoPayService.java
+++ b/src/main/java/zoo/insightnote/domain/payment/service/KakaoPayService.java
@@ -95,11 +95,9 @@ public class KakaoPayService {
     // 결제 승인 요청
     @Transactional
     public KakaoPayApproveResponseDto approveKakaoPayment(String tid, PaymentApproveRequestDto requestDto) {
-        // ✅ 승인 요청용 HttpEntity 생성
         HttpEntity<String> paymentApproveHttpEntity = createPaymentApproveHttpEntity(requestDto, tid);
 
         try {
-            // ✅ 카카오페이 승인 요청 실행
             ResponseEntity<KakaoPayApproveResponseDto> response = restTemplate.exchange(
                     "https://open-api.kakaopay.com/online/v1/payment/approve",
                     HttpMethod.POST,
@@ -107,12 +105,15 @@ public class KakaoPayService {
                     KakaoPayApproveResponseDto.class
             );
 
+            log.info("✅ 카카오페이 결제 승인 성공");
+
             return response.getBody();
         } catch (Exception e) {
             log.error("❌ 카카오페이 결제 승인 실패", e);
             throw new CustomException(ErrorCode.KAKAO_PAY_APPROVE_FAILED);
         }
     }
+
 
     private HttpEntity<String> createPaymentReqeustHttpEntity(PaymentRequestReadyDto requestDto, Long orderId) {
         HttpHeaders headers = new HttpHeaders();
@@ -175,4 +176,3 @@ public class KakaoPayService {
         return orderId;
     }
 }
-

--- a/src/main/java/zoo/insightnote/domain/payment/service/KakaoPayService.java
+++ b/src/main/java/zoo/insightnote/domain/payment/service/KakaoPayService.java
@@ -49,7 +49,7 @@ public class KakaoPayService {
     }
 
     // 결제 요청
-    public ResponseEntity<KakaoPayReadyResponseDto> requestPayment(PaymentRequestReadyDto requestDto) {
+    public ResponseEntity<KakaoPayReadyResponseDto> requestKakaoPayment(PaymentRequestReadyDto requestDto) {
         HttpEntity<String> paymentReqeustHttpEntity = createPaymentReqeustHttpEntity(requestDto);
 
         try {
@@ -74,8 +74,7 @@ public class KakaoPayService {
 
     // 결제 승인 요청
     @Transactional
-    public ResponseEntity<KakaoPayApproveResponseDto> approvePayment(String tid, PaymentApproveRequestDto requestDto) {
-
+    public KakaoPayApproveResponseDto approveKakaoPayment(String tid, PaymentApproveRequestDto requestDto) {
         // ✅ 승인 요청용 HttpEntity 생성
         HttpEntity<String> paymentApproveHttpEntity = createPaymentApproveHttpEntity(requestDto, tid);
 

--- a/src/main/java/zoo/insightnote/domain/payment/service/PaymentService.java
+++ b/src/main/java/zoo/insightnote/domain/payment/service/PaymentService.java
@@ -1,7 +1,80 @@
 package zoo.insightnote.domain.payment.service;
 
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import zoo.insightnote.domain.event.entity.Event;
+import zoo.insightnote.domain.event.repository.EventRepository;
+import zoo.insightnote.domain.payment.dto.request.PaymentApproveRequestDto;
+import zoo.insightnote.domain.payment.dto.response.KakaoPayApproveResponseDto;
+import zoo.insightnote.domain.payment.entity.Payment;
+import zoo.insightnote.domain.payment.entity.PaymentStatus;
+import zoo.insightnote.domain.payment.repository.PaymentRepository;
+import zoo.insightnote.domain.user.entity.User;
+import zoo.insightnote.domain.user.repository.UserRepository;
+import zoo.insightnote.global.exception.CustomException;
+import zoo.insightnote.global.exception.ErrorCode;
 
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class PaymentService {
+
+    private final KakaoPayService kakaoPayService;
+    private final PaymentRepository paymentRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final UserRepository userRepository;
+    private final EventRepository eventRepository;
+
+    @Transactional
+    public ResponseEntity<KakaoPayApproveResponseDto> approvePayment(PaymentApproveRequestDto requestDto) {
+        log.info("✅ 결제 승인 요청 도착! orderId: {}, userId: {}, pg_token: {}", requestDto.getOrderId(), requestDto.getUserId(), requestDto.getPgToken());
+
+        // ✅ Redis에서 tid 조회
+        String tidKey = "payment: " + requestDto.getOrderId();
+        String tid = redisTemplate.opsForValue().get(tidKey);
+        if (tid == null) {
+            log.error("❌ Redis에서 tid 조회 실패! (orderId={})",  requestDto.getOrderId());
+            throw new CustomException(ErrorCode.PAYMENT_NOT_FOUND);
+        }
+
+        ResponseEntity<KakaoPayApproveResponseDto> response = kakaoPayService.approvePayment(tid, requestDto);
+        savePaymentInfo(response.getBody());
+
+        return response;
+    }
+
+    private void savePaymentInfo(KakaoPayApproveResponseDto responseDto) {
+        User userInfo = findUserById(Long.valueOf(responseDto.getPartner_user_id()));
+        Event eventInfo = findEventById(Long.valueOf(100));
+
+        log.info("🔍 [결제 저장 직전] amount: {}", responseDto.getAmount().getTotalAmount());
+
+        Payment payment = Payment.builder()
+                .user(userInfo)
+                .event(eventInfo)
+                .email(userInfo.getEmail())
+                .phoneNumber(userInfo.getPhoneNumber())
+                .amount(responseDto.getAmount().getTotalAmount())
+                .paymentStatus(PaymentStatus.COMPLETED)
+                .build();
+
+        paymentRepository.save(payment);
+        log.info("✅ 결제 정보 저장 완료: {}", payment);
+    }
+
+    // TODO : 유저 도메인 개발 완료시 삭제
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(null, "User 사용자를 찾을 수 없습니다."));
+    }
+
+    // TODO : 유저 도메인 개발 완료시 삭제
+    private Event findEventById(Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new CustomException(null, "event 사용자를 찾을 수 없습니다."));
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/payment/service/PaymentService.java
+++ b/src/main/java/zoo/insightnote/domain/payment/service/PaymentService.java
@@ -41,8 +41,15 @@ public class PaymentService {
             throw new CustomException(ErrorCode.PAYMENT_NOT_FOUND);
         }
 
-        ResponseEntity<KakaoPayApproveResponseDto> response = kakaoPayService.approvePayment(tid, requestDto);
-        savePaymentInfo(response.getBody());
+        String getSessionIds = kakaoPayService.getSessionIds(requestDto.getOrderId());
+        if (getSessionIds == null) {
+            log.error("❌ Redis에서 sessions 조회 실패! (orderId={})",  requestDto.getOrderId());
+            throw new CustomException(ErrorCode.PAYMENT_NOT_FOUND);
+        }
+
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            List<Long> sessionIds = objectMapper.readValue(getSessionIds, new TypeReference<List<Long>>() {});
 
         return response;
     }

--- a/src/main/java/zoo/insightnote/domain/reservation/entity/Reservation.java
+++ b/src/main/java/zoo/insightnote/domain/reservation/entity/Reservation.java
@@ -11,12 +11,16 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import zoo.insightnote.domain.session.entity.Session;
 import zoo.insightnote.domain.user.entity.User;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Reservation {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## Summary

>- #16 
close #16 
카카오페이 결제 승인 시, 데이터 저장

## Tasks

- 결제 승인 시, 결제 내역 Payment 테이블에 저장
- 결제 승인 시, 유저 세션 예약 내역 Reservation 테이블 저장
- 주문 번호 생성

## To Reviewer

- 코드가 굉장히 난잡하게 되어 있습니다...! 🥲
- 이후 작업은 `결제 취소 구현`, `테스트 코드 작성`, `Payment 리팩토링` 순으로 진행할 예정입니다
민우 님이 이전번에 지적해주신 HttpEntity 생성하는 메소드들 이후 리팩토링에서 수정해보겠습니다!
- 이번에도 수정사항 있다면 바로 알려주세요