### PR TITLE
[#29] 로그인 후 토큰을 쿠키에서 헤더로 이동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+    // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 
-    //aws-s3
+    // aws-s3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 

--- a/src/main/java/zoo/insightnote/domain/user/controller/UserController.java
+++ b/src/main/java/zoo/insightnote/domain/user/controller/UserController.java
@@ -1,4 +1,14 @@
 package zoo.insightnote.domain.user.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+
+@Tag(name = "USER", description = "유저 관련 API")
 public interface UserController {
+
+    @Operation(summary = "쿠키 기반 토큰을 헤더로 변환", description = "쿠키에 저장된 토큰을 헤더로 변환합니다.")
+    ResponseEntity<?> convertTokenToHeader(@Parameter(description = "헤더에 저장된 토큰") @CookieValue(value = "Authorization", required = false) String token);
 }

--- a/src/main/java/zoo/insightnote/domain/user/controller/UserController.java
+++ b/src/main/java/zoo/insightnote/domain/user/controller/UserController.java
@@ -10,5 +10,5 @@ import org.springframework.web.bind.annotation.CookieValue;
 public interface UserController {
 
     @Operation(summary = "쿠키 기반 토큰을 헤더로 변환", description = "쿠키에 저장된 토큰을 헤더로 변환합니다.")
-    ResponseEntity<?> convertTokenToHeader(@Parameter(description = "헤더에 저장된 토큰") @CookieValue(value = "Authorization", required = false) String token);
+    ResponseEntity<?> convertTokenToHeader(@Parameter(description = "쿠키에 저장된 토큰") @CookieValue(value = "Authorization", required = false) String token);
 }

--- a/src/main/java/zoo/insightnote/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/user/controller/UserControllerImpl.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import zoo.insightnote.global.jwt.JWTUtil;
 
 @RestController
-@RequestMapping("/user")
+@RequestMapping("api/v1/user")
 @RequiredArgsConstructor
 public class UserControllerImpl implements UserController {
 

--- a/src/main/java/zoo/insightnote/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/user/controller/UserControllerImpl.java
@@ -1,7 +1,27 @@
 package zoo.insightnote.domain.user.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import zoo.insightnote.global.jwt.JWTUtil;
 
 @RestController
-public class UserControllerImpl implements UserController{
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserControllerImpl implements UserController {
+
+    private final JWTUtil jwtUtil;
+
+    @GetMapping("/auth/token")
+    public ResponseEntity<?> convertTokenToHeader(@CookieValue(value = "Authorization", required = false) String token) {
+        if (token == null || jwtUtil.isExpired(token)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Token expired or not found");
+        }
+
+        return ResponseEntity.ok().header("Authorization", "Bearer " + token).build();
+    }
 }

--- a/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
@@ -86,7 +86,7 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger 문서 접근 허용
+                        .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/user/auth/token").permitAll() // Swagger 문서 접근 허용
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/zoo/insightnote/global/config/SwaggerConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package zoo.insightnote.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,8 +13,17 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components())
+                .components(new Components().addSecuritySchemes("BearerAuth", securityScheme())) // 🔽 JWT 인증 설정 추가
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
                 .info(apiInfo());
+    }
+
+    private SecurityScheme securityScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .name("Authorization");
     }
 
     private Info apiInfo() {

--- a/src/main/java/zoo/insightnote/global/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/zoo/insightnote/global/oauth2/CustomSuccessHandler.java
@@ -23,6 +23,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Value("${FRONT_URL}")
     private String frontUrl;
 
+    private static final long EXPIRATION_TIME = 10 * 60 * 60 * 1000L; // 10시간 (refresh token 적용시 변경 예정)
+
     private final JWTUtil jwtUtil;
 
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -34,7 +36,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
         GrantedAuthority auth = iterator.next();
         String role = auth.getAuthority();
-        String token = jwtUtil.createJwt(username, role, 60*60*60L);
+        String token = jwtUtil.createJwt(username, role, EXPIRATION_TIME);
 
         response.addCookie(createCookie("Authorization", token));
         response.sendRedirect(frontUrl); // 추후 프론트 배포 서버로 변경 해야됨.


### PR DESCRIPTION
## Summary

#29 
closed #29 

1. 로그인 성공 후 토큰을 쿠키로 발급하여 프론트의 특정 페이지(localhost:3000)로 리디렉션을 보냄
2. 프론트에서 axios를 통해 쿠키를(credentials=true)를 가지고 다시 백엔드로 api 요청하여 헤더로 토큰을 받아옴
3. 헤더로 받아온 토큰을 로컬 스토리지에 보관하여 사용
이러한 로직이 가능하도록 설정

## Tasks

- 쿠키에 저장되어 있는 토큰을 프론트에서 받아서 헤더에 저장 가능하도록 로직 추가
- swagger 관련 설정들 추가

## Screenshot
![image](https://github.com/user-attachments/assets/63719c70-e66a-4c56-81f0-6f2a0f0a60a6)
