### PR TITLE
[#36] 세션 조회 중복 현상 제거 

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Set target server variables
         run: |
-          STATUS=$(curl -o /dev/null -w "%{http_code}" "http://${{ secrets.LIVE_SERVER_IP }}/actuator/env")
+          STATUS=$(curl -o /dev/null -w "%{http_code}" "https://${{ secrets.LIVE_SERVER_IP }}/actuator/env")
           if [ $STATUS = 200 ]; then
-               CURRENT_UPSTREAM=$(curl -s "http://${{ secrets.LIVE_SERVER_IP }}/actuator/env" | jq -r '.activeProfiles[0]')
+               CURRENT_UPSTREAM=$(curl -s "https://${{ secrets.LIVE_SERVER_IP }}/actuator/env" | jq -r '.activeProfiles[0]')
           else
           CURRENT_UPSTREAM=green
           fi
@@ -98,7 +98,7 @@ jobs:
       - name: Check deploy server URL
         uses: jtalk/url-health-check-action@v3
         with:
-          url: http://${{ secrets.LIVE_SERVER_IP }}:${{env.STOPPED_PORT}}/actuator/env
+          url: http://${{ secrets.LIVE_SERVER_IP }}:${{env.STOPPED_PORT}}/swagger-ui/index.html?continue#/
           max-attempts: 3
           retry-delay: 10s
 

--- a/src/main/java/zoo/insightnote/domain/session/dto/SessionResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/session/dto/SessionResponseDto.java
@@ -7,6 +7,7 @@ import zoo.insightnote.domain.session.entity.SessionStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 
 public class SessionResponseDto {
@@ -28,11 +29,11 @@ public class SessionResponseDto {
     }
 
     @Getter
-    @Builder
+    @Builder(toBuilder = true)
     public static class SessionAllRes {
         private Long id;
         private String name;
-        private List<String> keywords;
+        private Set<String> keywords;
         private String shortDescription;
         private LocalDateTime startTime;
         private LocalDateTime endTime;
@@ -41,11 +42,11 @@ public class SessionResponseDto {
     }
 
     @Getter
-    @Builder
+    @Builder(toBuilder = true)
     public static class SessionDetailedRes {
         private Long id;
         private String name;
-        private List<String> keywords;
+        private Set<String> keywords;
         private String speakerName;
         private String speakerImageUrl;
         private String shortDescription;

--- a/src/main/java/zoo/insightnote/domain/session/mapper/SessionMapper.java
+++ b/src/main/java/zoo/insightnote/domain/session/mapper/SessionMapper.java
@@ -6,6 +6,7 @@ import zoo.insightnote.domain.session.dto.SessionResponseDto;
 import zoo.insightnote.domain.session.entity.Session;
 import zoo.insightnote.domain.speaker.entity.Speaker;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 
 public class SessionMapper {
@@ -53,7 +54,7 @@ public class SessionMapper {
                 .speakerName(session.getSpeaker().getName())
                 .speakerImageUrl(speakerImageUrl)
                 .maxCapacity(participantCount)
-                .keywords(keywords)
+                .keywords(new LinkedHashSet<>(keywords))
                 .status(session.getStatus())
                 .location(session.getLocation())
                 .build();

--- a/src/main/java/zoo/insightnote/domain/session/repository/SessionRepository.java
+++ b/src/main/java/zoo/insightnote/domain/session/repository/SessionRepository.java
@@ -12,20 +12,21 @@ import java.util.List;
 public interface SessionRepository extends JpaRepository<Session, Long> {
 
 
-// 1. 세션 전체 조회 (연사 이미지 제외, 인원수 제외, 키워드 포함)
+
+    // 1. 세션 전체 조회 (연사 이미지 제외, 인원수 제외, 키워드 포함)
     @Query("""
-    SELECT s.id, s.name, k.name, s.shortDescription, s.location,s.startTime, s.endTime
-    FROM Session s
-    LEFT JOIN SessionKeyword sk ON sk.session.id = s.id
-    LEFT JOIN Keyword k ON sk.keyword.id = k.id
-    ORDER BY s.id ASC
+        SELECT s.id, s.name, k.name, s.shortDescription, s.location, s.startTime, s.endTime
+        FROM Session s
+        LEFT JOIN SessionKeyword sk ON sk.session.id = s.id
+        LEFT JOIN Keyword k ON sk.keyword.id = k.id
+        ORDER BY s.id ASC
     """)
     List<Object[]> findAllSessions();
 
     // 2. 세션 상세 조회 (연사 이미지, 인원수 포함, 키워드 포함)
     @Query("""
-    SELECT s.id, s.name, k.name, s.shortDescription, s.maxCapacity, s.participantCount, s.location,
-        sp.name, img.fileUrl,s.startTime, s.endTime, s.status
+    SELECT s.id, s.name, s.shortDescription, s.maxCapacity, s.participantCount, 
+           s.location, sp.name, img.fileUrl, s.startTime, s.endTime, s.status, k.name
     FROM Session s
     JOIN Speaker sp ON s.speaker.id = sp.id
     LEFT JOIN Image img ON img.entityId = sp.id AND img.entityType = :entityType
@@ -34,6 +35,8 @@ public interface SessionRepository extends JpaRepository<Session, Long> {
     ORDER BY
         CASE WHEN s.maxCapacity = s.participantCount THEN 1 ELSE 0 END ASC, 
         s.id ASC
-    """)
+""")
     List<Object[]> findAllSessionsWithDetails(@Param("entityType") EntityType entityType);
 }
+
+

--- a/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
+++ b/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
@@ -139,7 +139,7 @@ public class SessionService {
                     .startTime(startTime)
                     .endTime(endTime)
                     .timeRange(timeRange)
-                    .keywords(new ArrayList<>())
+                    .keywords(new LinkedHashSet<>())
                     .build());
 
             // 키워드 중복 방지하여 추가
@@ -201,7 +201,7 @@ public class SessionService {
                     .endTime(endTime)
                     .status((SessionStatus) row[10])
                     .timeRange(timeRange)
-                    .keywords(new ArrayList<>())
+                    .keywords(new LinkedHashSet<>())
                     .build());
 
             // 키워드 중복 방지하여 추가


### PR DESCRIPTION
## Summary

>- close #36 

세션 전체 조회 get 요청 유형 2개의 api 에서 데이터를 키워드 수에 따라 중복으로 가져오는 현상발생 
jpql 에서는 GROUP_CONCAT 함수를 지원하지 않아서 임시로 서비스 로직에서 임시로 중복 제거

GROUP_CONCAT 을 사용하지 않으면 db에서 데이터를 가져올떄 불필요한 중복데이터를 n 만큼 가져오기때문에 반드시 수정이 필요합니다  

## Tasks

- 서비스 로직 수정

## To Reviewer

현재 jpql 사용하면서 발생한  문제점 리펙토링을 바로 개선하려고 합니다 
- GROUP_CONCAT 함수가 지원되지 않는 문제를 해결하기 위해서 스프링에서 함수를 가져오는 방법 적용이 필요함 
 - 서비스 로직 코드가  비지니스 로직 때문에 코드가 상당히 어지럽고 책임이 분활되지 않음
 - jqpl을 query dsl 학습후 개선이 필요하면 적용이 필요함 


## Screenshot

