### PR TITLE
[#59] 세션 모달 페이지 중복문제 +  출력 필드 추가 (세션,연사,키워드,이미지) 출력 

### DIFF
--- a/src/main/java/zoo/insightnote/domain/session/dto/SessionResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/session/dto/SessionResponseDto.java
@@ -87,7 +87,7 @@ public class SessionResponseDto {
         private String speakerName;
         private List<String> keywords;
         private List<String> careers;
-
+        private String imageUrl;
     }
 
     @Data
@@ -103,5 +103,6 @@ public class SessionResponseDto {
         private String speakerName;
         private String keywords;
         private String careers;
+        private String imageUrl;
     }
 }

--- a/src/main/java/zoo/insightnote/domain/session/mapper/SessionMapper.java
+++ b/src/main/java/zoo/insightnote/domain/session/mapper/SessionMapper.java
@@ -79,20 +79,6 @@ public class SessionMapper {
 
     public static SessionResponseDto.SessionSpeakerDetailRes toSessionSpeakerDetailRes(SessionResponseDto.SessionSpeakerDetailQueryDto result) {
 
-
-        // # 1번 case
-//        해당 주석은 중복 이슈를 팀원간 공유를 하고 삭제하거나 수정할 부분입니다
-//        List<String> keywords = Optional.ofNullable(result.getKeywords())
-//                .map(k -> List.of(k.split(",")))
-//                .orElse(Collections.emptyList());
-//
-//        List<String> careers = Optional.ofNullable(result.getCareers())
-//                .map(c -> List.of(c.split(",")))
-//                .orElse(Collections.emptyList());
-
-
-        // # 2번 case
-        // keywords 처리 (빈 문자열 제거)
         List<String> keywords = Optional.ofNullable(result.getKeywords())
                 .map(k -> Arrays.stream(k.split(","))
                         .filter(s -> !s.isBlank())  // 빈 문자열 제거
@@ -101,12 +87,12 @@ public class SessionMapper {
                 .orElse(Collections.emptyList());
 
         List<String> careers = Optional.ofNullable(result.getCareers())
-                .map(c -> c.replace(", ", "##SEP##"))           // 먼저 쉼표 + 공백을 특수 구분자로 치환
-                .map(c -> Arrays.stream(c.split(","))           // 먼저 쉼표로 1차 분리
-                        .map(s -> s.replace("##SEP##", ", "))    // 다시 원래의 쉼표 + 공백으로 복구
-                        .map(String::trim)                      // 공백 제거
-                        .filter(s -> !s.isBlank())              // 빈 문자열 제거
-                        .distinct()                             // 중복 제거
+                .map(c -> c.replace(", ", "##SEP##"))
+                .map(c -> Arrays.stream(c.split(","))
+                        .map(s -> s.replace("##SEP##", ", "))
+                        .map(String::trim)
+                        .filter(s -> !s.isBlank())
+                        .distinct()
                         .toList())
                 .orElseGet(ArrayList::new);
 

--- a/src/main/java/zoo/insightnote/domain/session/repository/CustomFunctionContributor.java
+++ b/src/main/java/zoo/insightnote/domain/session/repository/CustomFunctionContributor.java
@@ -1,27 +1,33 @@
-package zoo.insightnote.domain.session.repository;
-
-import org.hibernate.boot.model.FunctionContributions;
-import org.hibernate.boot.model.FunctionContributor;
-import org.hibernate.query.sqm.function.SqmFunctionRegistry;
-import org.hibernate.type.StandardBasicTypes;
-
-public class CustomFunctionContributor implements FunctionContributor {
-
-    @Override
-    public void contributeFunctions(FunctionContributions functionContributions) {
-        SqmFunctionRegistry functionRegistry = functionContributions.getFunctionRegistry();
-
-        // group_concat 함수 등록
+//package zoo.insightnote.domain.session.repository;
+//
+//import org.hibernate.boot.model.FunctionContributions;
+//import org.hibernate.boot.model.FunctionContributor;
+//import org.hibernate.query.sqm.function.SqmFunctionRegistry;
+//import org.hibernate.type.StandardBasicTypes;
+//
+//public class CustomFunctionContributor implements FunctionContributor {
+//
+//    @Override
+//    public void contributeFunctions(FunctionContributions functionContributions) {
+//        SqmFunctionRegistry functionRegistry = functionContributions.getFunctionRegistry();
+//
+//        // group_concat 함수 등록
+////        functionRegistry.registerPattern(
+////                "group_concat",
+////                "group_concat(distinct ?1 separator ',')",
+////                functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve(StandardBasicTypes.STRING)
+////        );
+//
+////        functionRegistry.registerPattern(
+////                "group_concat",
+////                "group_concat(distinct ?1 separator ?2)", // separator를 파라미터로 처리
+////                functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve(StandardBasicTypes.STRING)
+////        );
+//
 //        functionRegistry.registerPattern(
 //                "group_concat",
-//                "group_concat(distinct ?1 separator ',')",
+//                "group_concat(?1 separator ?2)", // separator를 파라미터로 처리
 //                functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve(StandardBasicTypes.STRING)
 //        );
-
-        functionRegistry.registerPattern(
-                "group_concat",
-                "group_concat(distinct ?1 separator ?2)", // separator를 파라미터로 처리
-                functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve(StandardBasicTypes.STRING)
-        );
-    }
-}
+//    }
+//}

--- a/src/main/java/zoo/insightnote/domain/session/repository/SessionCustomQueryRepository.java
+++ b/src/main/java/zoo/insightnote/domain/session/repository/SessionCustomQueryRepository.java
@@ -21,6 +21,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static zoo.insightnote.domain.image.entity.QImage.image;
+
 @Repository
 @RequiredArgsConstructor
 public class SessionCustomQueryRepository {
@@ -236,6 +238,7 @@ public class SessionCustomQueryRepository {
         QSessionKeyword sessionKeyword = QSessionKeyword.sessionKeyword;
         QKeyword keyword = QKeyword.keyword;
         QCareer career = QCareer.career;
+        QImage image = QImage.image;
 
         return queryFactory
                 .select(Projections.constructor(
@@ -246,16 +249,22 @@ public class SessionCustomQueryRepository {
                         session.maxCapacity,
                         session.participantCount,
                         speaker.name,
-                        Expressions.stringTemplate("group_concat({0}, {1})", keyword.name, Expressions.constant(",")),  // 쉼표 구분자
-                        Expressions.stringTemplate("group_concat({0}, {1})", career.description, Expressions.constant("||")) // '||' 구분자
+//                        Expressions.stringTemplate("group_concat({0}, {1})", keyword.name, Expressions.constant(",")),  // 쉼표 구분자
+//                        Expressions.stringTemplate("group_concat({0}, {1})", career.description, Expressions.constant("||")), // '||' 구분자
+
+                        Expressions.stringTemplate("group_concat(distinct {0})", keyword.name, Expressions.constant(",")),  // 쉼표 구분자
+                        Expressions.stringTemplate("group_concat(distinct {0})", career.description), // '||' 구분자
+                        Expressions.stringTemplate("MAX({0})", image.fileUrl)
                 ))
                 .from(session)
                 .join(session.speaker, speaker)
                 .leftJoin(sessionKeyword).on(sessionKeyword.session.eq(session))
                 .leftJoin(sessionKeyword.keyword, keyword)
                 .leftJoin(career).on(career.speaker.eq(speaker))
+                .leftJoin(image).on(image.entityId.eq(speaker.id).and(image.entityType.eq(EntityType.SPEAKER)))
                 .where(session.id.eq(sessionId))
-                .groupBy(session.id)
                 .fetchOne();
     }
+
+
 }

--- a/src/main/java/zoo/insightnote/domain/session/repository/SessionCustomQueryRepository.java
+++ b/src/main/java/zoo/insightnote/domain/session/repository/SessionCustomQueryRepository.java
@@ -249,19 +249,18 @@ public class SessionCustomQueryRepository {
                         session.maxCapacity,
                         session.participantCount,
                         speaker.name,
-//                        Expressions.stringTemplate("group_concat({0}, {1})", keyword.name, Expressions.constant(",")),  // 쉼표 구분자
-//                        Expressions.stringTemplate("group_concat({0}, {1})", career.description, Expressions.constant("||")), // '||' 구분자
-
                         Expressions.stringTemplate("group_concat(distinct {0})", keyword.name, Expressions.constant(",")),  // 쉼표 구분자
                         Expressions.stringTemplate("group_concat(distinct {0})", career.description), // '||' 구분자
                         Expressions.stringTemplate("MAX({0})", image.fileUrl)
+
                 ))
                 .from(session)
                 .join(session.speaker, speaker)
                 .leftJoin(sessionKeyword).on(sessionKeyword.session.eq(session))
                 .leftJoin(sessionKeyword.keyword, keyword)
                 .leftJoin(career).on(career.speaker.eq(speaker))
-                .leftJoin(image).on(image.entityId.eq(speaker.id).and(image.entityType.eq(EntityType.SPEAKER)))
+                .leftJoin(image)
+                    .on(image.entityId.eq(speaker.id).and(image.entityType.stringValue().eq("SPEAKER")))
                 .where(session.id.eq(sessionId))
                 .fetchOne();
     }

--- a/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
+++ b/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
@@ -57,7 +57,7 @@ public class SessionService {
                 .toList();
         sessionKeywordService.saveSessionKeywords(savedSession, keywords);
 
-        return SessionMapper.toResponse(session, request.getKeywords());
+        return SessionMapper.  toResponse(session, request.getKeywords());
     }
 
 
@@ -109,12 +109,12 @@ public class SessionService {
         return sessionQueryRepository.findAllSessionsWithDetails(EntityType.SPEAKER);
     }
 
-
-
     @Transactional(readOnly = true)
     public SessionResponseDto.SessionSpeakerDetailRes getSessionDetails(Long sessionId) {
         SessionResponseDto.SessionSpeakerDetailQueryDto result = sessionQueryRepository.findSessionAndSpeakerDetail(sessionId);
 
+        System.out.println("4444444444");
+        System.out.println(result.getImageUrl());
         if (result == null) {
             throw new CustomException(ErrorCode.SESSION_NOT_FOUND); // 커스텀 예외로 처리
         }

--- a/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
+++ b/src/main/java/zoo/insightnote/domain/session/service/SessionService.java
@@ -113,8 +113,6 @@ public class SessionService {
     public SessionResponseDto.SessionSpeakerDetailRes getSessionDetails(Long sessionId) {
         SessionResponseDto.SessionSpeakerDetailQueryDto result = sessionQueryRepository.findSessionAndSpeakerDetail(sessionId);
 
-        System.out.println("4444444444");
-        System.out.println(result.getImageUrl());
         if (result == null) {
             throw new CustomException(ErrorCode.SESSION_NOT_FOUND); // 커스텀 예외로 처리
         }


### PR DESCRIPTION
## Summary

>- close #59 



## Tasks
- api 출력 응답값에서 발생하는 연사 이력 중복문제를 해결하고 이미지 url도 가져오도록 쿼리와 매퍼를 수정했습니다 

## To Reviewer

팀원에게 공유할 문제점 발견 
data.sql 때문에 현재 DB를 확인하면 session_speaker 가 데이터가 계속 중첩되어서 쌓이고 있습니다 
 [이유] session_speaker 는 데이터 생성시에 id 가 지정되어 있지 않아서 스프링 재실행시 계속 생성되고 있습니다 
 저희 깃에서 data.sql을 삭제하거나 적용이 되지 않는 방법이 필요합니다   

아래 사진을 보면 데이터가 800개 100개 이상 생성된 문제를 볼 수 있습니다 
![스크린샷 2025-03-15 오후 11 29 37](https://github.com/user-attachments/assets/75fb50f1-93d3-4d40-9538-3e80d312b4b7)
![스크린샷 2025-03-15 오후 11 29 51](https://github.com/user-attachments/assets/9ca6897f-8b0c-42b9-820f-3fa19bc3b789)



## Screenshot

![스크린샷 2025-03-15 오후 11 26 44](https://github.com/user-attachments/assets/b06e1190-a7bd-41ad-8493-440ce8239118)

