### PR TITLE
[#69] 인사이트 목록,상세,댓글 출력 관련 api 구현 

### DIFF
--- a/src/main/java/zoo/insightnote/domain/comment/controller/CommentController.java
+++ b/src/main/java/zoo/insightnote/domain/comment/controller/CommentController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import zoo.insightnote.domain.comment.dto.CommentRequest;
 import zoo.insightnote.domain.comment.dto.CommentResponse;
+import zoo.insightnote.domain.comment.dto.CommentResponseDto;
 
 @Tag(name = "Comment API", description = "댓글 관련 API")
 public interface CommentController {
@@ -21,9 +22,9 @@ public interface CommentController {
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody CommentRequest.Create request);
 
-    @Operation(summary = "댓글 목록 조회", description = "특정 인사이트의 댓글 목록을 조회합니다.")
-    ResponseEntity<List<CommentResponse>> listComments(
-            @Parameter(description = "인사이트 ID") @PathVariable Long insightId);
+//    @Operation(summary = "댓글 목록 조회", description = "특정 인사이트의 댓글 목록을 조회합니다.")
+//    ResponseEntity<List<CommentResponse>> listComments(
+//            @Parameter(description = "인사이트 ID") @PathVariable Long insightId);
 
     @Operation(summary = "댓글 수정", description = "작성자가 본인의 댓글을 수정합니다.")
     ResponseEntity<CommentResponse> updateComment(
@@ -38,4 +39,7 @@ public interface CommentController {
             @Parameter(description = "댓글 ID") @PathVariable Long commentId,
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails);
 
+    @Operation(summary = "댓글 목록 조회", description = "특정 인사이트의 댓글 목록을 조회합니다.")
+    ResponseEntity<List<CommentResponseDto>> getListComments(
+            @Parameter(description = "인사이트 ID") @PathVariable Long insightId);
 }

--- a/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import zoo.insightnote.domain.comment.dto.CommentRequest;
 import zoo.insightnote.domain.comment.dto.CommentRequest.Create;
 import zoo.insightnote.domain.comment.dto.CommentResponse;
+import zoo.insightnote.domain.comment.dto.CommentResponseDto;
 import zoo.insightnote.domain.comment.service.CommentService;
 
 @RestController
@@ -37,11 +38,11 @@ public class CommentControllerImpl implements CommentController {
         return ResponseEntity.ok().body(response);
     }
 
-    @Override
-    @GetMapping("/{insightId}/comments")
-    public ResponseEntity<List<CommentResponse>> listComments(@PathVariable Long insightId) {
-        return ResponseEntity.ok().body(commentService.findCommentsByInsightId(insightId));
-    }
+//    @Override
+//    @GetMapping("/{insightId}/comments")
+//    public ResponseEntity<List<CommentResponse>> listComments(@PathVariable Long insightId) {
+//        return ResponseEntity.ok().body(commentService.findCommentsByInsightId(insightId));
+//    }
 
     @Override
     @PutMapping("/{insightId}/comments/{commentId}")
@@ -72,6 +73,14 @@ public class CommentControllerImpl implements CommentController {
         return new User("001", "password", Collections.emptyList());
     }
 
+
+    // 댓글 리스트 출력
+    @Override
+    @GetMapping("/comments/{insightId}")
+    public ResponseEntity<List<CommentResponseDto>> getListComments(@PathVariable Long insightId) {
+        List<CommentResponseDto> comments = commentService.getCommentsByInsight(insightId);
+        return ResponseEntity.ok(comments);
+    }
 }
 
 

--- a/src/main/java/zoo/insightnote/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/comment/dto/CommentResponseDto.java
@@ -1,0 +1,34 @@
+package zoo.insightnote.domain.comment.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import zoo.insightnote.domain.comment.entity.Comment;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@AllArgsConstructor
+public class CommentResponseDto {
+    private Long id;
+    private String name;
+    private String createdAt;
+    private boolean edited;
+    private String role;
+    private String content;
+
+    public CommentResponseDto(Comment comment) {
+        this.id = comment.getId();
+        this.name = comment.getUser().getName();  // User 엔티티에 name 필드가 있다고 가정
+        this.createdAt = formatDate(comment.getCreateAt());
+        this.edited = comment.isUpdated();
+        this.role = comment.getUser().getRole().toString(); // User 엔티티에 role 필드가 있다고 가정
+        this.content = comment.getContent();
+    }
+
+    private String formatDate(LocalDateTime dateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return dateTime.format(formatter);
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/comment/entity/Comment.java
+++ b/src/main/java/zoo/insightnote/domain/comment/entity/Comment.java
@@ -45,5 +45,9 @@ public class Comment extends BaseTimeEntity {
         }
     }
 
+    public boolean isUpdated() {
+        return this.getUpdatedAt() != null && !this.getCreateAt().isEqual(this.getUpdatedAt());
+    }
+
 }
 

--- a/src/main/java/zoo/insightnote/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/zoo/insightnote/domain/comment/repository/CommentRepository.java
@@ -3,9 +3,13 @@ package zoo.insightnote.domain.comment.repository;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import zoo.insightnote.domain.comment.entity.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c FROM Comment c WHERE c.insight.id = :insightId")
     List<Comment> findAllByInsightId(Long insightId);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.insight.id = :insightId")
+    List<Comment> findByInsightIdWithUser(@Param("insightId") Long insightId);
 }

--- a/src/main/java/zoo/insightnote/domain/comment/service/CommentService.java
+++ b/src/main/java/zoo/insightnote/domain/comment/service/CommentService.java
@@ -2,11 +2,14 @@ package zoo.insightnote.domain.comment.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import zoo.insightnote.domain.comment.dto.CommentRequest;
 import zoo.insightnote.domain.comment.dto.CommentResponse;
+import zoo.insightnote.domain.comment.dto.CommentResponseDto;
 import zoo.insightnote.domain.comment.entity.Comment;
 import zoo.insightnote.domain.comment.mapper.CommentMapper;
 import zoo.insightnote.domain.comment.repository.CommentRepository;
@@ -73,6 +76,17 @@ public class CommentService {
         commentRepository.deleteById(commentId);
 
         return new CommentResponse.Delete(commentId);
+    }
+
+    public List<CommentResponseDto> getCommentsByInsight(Long insightId) {
+
+        // 예외처리 로직 필요함
+
+        List<Comment> comments = commentRepository.findByInsightIdWithUser(insightId);
+
+        return comments.stream()
+                .map(CommentResponseDto::new)
+                .collect(Collectors.toList());
     }
 
     public Comment findCommentById(Long commentId) {

--- a/src/main/java/zoo/insightnote/domain/insight/controller/InsightController.java
+++ b/src/main/java/zoo/insightnote/domain/insight/controller/InsightController.java
@@ -39,17 +39,17 @@ public interface InsightController {
             @RequestBody InsightRequestDto.CreateDto request
     );
 
-    @Operation(summary = "인사이트 수정", description = "기존 인사이트 정보를 수정합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "인사이트 수정 성공"),
-            @ApiResponse(responseCode = "404", description = "인사이트를 찾을 수 없음"),
-            @ApiResponse(responseCode = "500", description = "서버 오류")
-    })
-    @PutMapping("/{insightId}")
-    ResponseEntity<InsightResponseDto.InsightRes> updateInsight(
-            @Parameter(description = "수정할 인사이트 ID") @PathVariable Long insightId,
-            @RequestBody InsightRequestDto.UpdateDto request
-    );
+//    @Operation(summary = "인사이트 수정", description = "기존 인사이트 정보를 수정합니다.")
+//    @ApiResponses(value = {
+//            @ApiResponse(responseCode = "200", description = "인사이트 수정 성공"),
+//            @ApiResponse(responseCode = "404", description = "인사이트를 찾을 수 없음"),
+//            @ApiResponse(responseCode = "500", description = "서버 오류")
+//    })
+//    @PutMapping("/{insightId}")
+//    ResponseEntity<InsightResponseDto.InsightRes> updateInsight(
+//            @Parameter(description = "수정할 인사이트 ID") @PathVariable Long insightId,
+//            @RequestBody InsightRequestDto.UpdateDto request
+//    );
 
     @Operation(summary = "인사이트 삭제", description = "특정 ID의 인사이트를 삭제합니다.")
     @ApiResponses(value = {
@@ -62,16 +62,16 @@ public interface InsightController {
             @Parameter(description = "삭제할 인사이트 ID") @PathVariable Long insightId
     );
 
-    @Operation(summary = "특정 인사이트 조회", description = "ID를 이용해 특정 인사이트 정보를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "인사이트 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "인사이트를 찾을 수 없음"),
-            @ApiResponse(responseCode = "500", description = "서버 오류")
-    })
-    @GetMapping("/{insightId}")
-    ResponseEntity<InsightResponseDto.InsightRes> getInsightById(
-            @Parameter(description = "조회할 인사이트 ID") @PathVariable Long insightId
-    );
+//    @Operation(summary = "특정 인사이트 조회", description = "ID를 이용해 특정 인사이트 정보를 조회합니다.")
+//    @ApiResponses(value = {
+//            @ApiResponse(responseCode = "200", description = "인사이트 조회 성공"),
+//            @ApiResponse(responseCode = "404", description = "인사이트를 찾을 수 없음"),
+//            @ApiResponse(responseCode = "500", description = "서버 오류")
+//    })
+//    @GetMapping("/{insightId}")
+//    ResponseEntity<InsightResponseDto.InsightRes> getInsightById(
+//            @Parameter(description = "조회할 인사이트 ID") @PathVariable Long insightId
+//    );
 
     @Operation(summary = "좋아요 등록/취소",
             description = """

--- a/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
@@ -63,19 +63,19 @@ public class InsightControllerImpl implements InsightController{
 
     // 인기순위 상위 3개 가져오기
     @GetMapping("/top")
-    public ResponseEntity<List<Insight>> getTop3Insights() {
-        List<Insight> insights = insightService.getTop3PopularInsights();
-        return ResponseEntity.ok(insights);
+    public ResponseEntity<List<InsightResponseDto.InsightTopRes>> getTop3PopularInsights() {
+        List<InsightResponseDto.InsightTopRes> topInsights = insightService.getTopPopularInsights();
+        return ResponseEntity.ok(topInsights);
     }
 
     // 인사이트 목록 9개 기준 (시간순 정렬)
     // 무한 스크롤 (페이징)
 
     @GetMapping("/list")
-    public ResponseEntity<List<Insight>> getInsightsByEventDay(
+    public ResponseEntity<List<InsightResponseDto.InsightByEventDayRes>> getInsightsByEventDay(
             @RequestParam("eventDay") LocalDate eventDay,
             @RequestParam(value = "page", defaultValue = "0") int page) {
-        List<Insight> insights = insightService.getInsightsByEventDay(eventDay, page);
+        List<InsightResponseDto.InsightByEventDayRes> insights = insightService.getInsightsByEventDay(eventDay, page);
         return ResponseEntity.ok(insights);
     }
 

--- a/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
@@ -70,14 +70,15 @@ public class InsightControllerImpl implements InsightController{
 
     // 인사이트 목록 9개 기준 (시간순 정렬)
     // 무한 스크롤 (페이징)
-
     @GetMapping("/list")
-    public ResponseEntity<List<InsightResponseDto.InsightListPageRes>> getInsightsByEventDay(
+    public ResponseEntity<InsightResponseDto.InsightListPageRes> getInsightsByEventDay(
             @RequestParam("eventDay") LocalDate eventDay,
             @RequestParam(value = "page", defaultValue = "0") int page) {
-        List<InsightResponseDto.InsightListPageRes> insights = insightService.getInsightsByEventDay(eventDay, page);
+
+        InsightResponseDto.InsightListPageRes insights = insightService.getInsightsByEventDay(eventDay, page);
         return ResponseEntity.ok(insights);
     }
+
 
     // 인사이트 상세 페이지
     @GetMapping("/{insightId}")

--- a/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
@@ -27,14 +27,14 @@ public class InsightControllerImpl implements InsightController{
         return ResponseEntity.ok(insight);
     }
 
-    @Override
-    @PutMapping("/{insightId}")
-    public ResponseEntity<InsightResponseDto.InsightRes> updateInsight(
-            @PathVariable Long insightId,
-            @RequestBody InsightRequestDto.UpdateDto request) {
-        InsightResponseDto.InsightRes updatedInsight = insightService.updateInsight(insightId, request);
-        return ResponseEntity.ok(updatedInsight);
-    }
+//    @Override
+//    @PutMapping("/{insightId}")
+//    public ResponseEntity<InsightResponseDto.InsightRes> updateInsight(
+//            @PathVariable Long insightId,
+//            @RequestBody InsightRequestDto.UpdateDto request) {
+//        InsightResponseDto.InsightRes updatedInsight = insightService.updateInsight(insightId, request);
+//        return ResponseEntity.ok(updatedInsight);
+//    }
 
     @Override
     @DeleteMapping("/{insightId}")
@@ -43,12 +43,12 @@ public class InsightControllerImpl implements InsightController{
         return ResponseEntity.noContent().build();
     }
 
-    @Override
-    @GetMapping("/{insightId}")
-    public ResponseEntity<InsightResponseDto.InsightRes> getInsightById(@PathVariable Long insightId) {
-        InsightResponseDto.InsightRes insight = insightService.getInsightById(insightId);
-        return ResponseEntity.ok(insight);
-    }
+//    @Override
+//    @GetMapping("/{insightId}")
+//    public ResponseEntity<InsightResponseDto.InsightRes> getInsightById(@PathVariable Long insightId) {
+//        InsightResponseDto.InsightRes insight = insightService.getInsightById(insightId);
+//        return ResponseEntity.ok(insight);
+//    }
 
     //  좋아요 등록/취소 API
     @PostMapping("/{insightId}/like")
@@ -80,10 +80,11 @@ public class InsightControllerImpl implements InsightController{
     }
 
     // 인사이트 상세 페이지
-
-
-
-
+    @GetMapping("/{insightId}")
+    public ResponseEntity<InsightResponseDto.InsightDetailRes> getInsightDetail(@PathVariable Long insightId) {
+        InsightResponseDto.InsightDetailRes insightDetail = insightService.getInsightDetail(insightId);
+        return ResponseEntity.ok(insightDetail);
+    }
 
 
 

--- a/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
@@ -72,17 +72,17 @@ public class InsightControllerImpl implements InsightController{
     // 무한 스크롤 (페이징)
 
     @GetMapping("/list")
-    public ResponseEntity<List<InsightResponseDto.InsightByEventDayRes>> getInsightsByEventDay(
+    public ResponseEntity<List<InsightResponseDto.InsightListPageRes>> getInsightsByEventDay(
             @RequestParam("eventDay") LocalDate eventDay,
             @RequestParam(value = "page", defaultValue = "0") int page) {
-        List<InsightResponseDto.InsightByEventDayRes> insights = insightService.getInsightsByEventDay(eventDay, page);
+        List<InsightResponseDto.InsightListPageRes> insights = insightService.getInsightsByEventDay(eventDay, page);
         return ResponseEntity.ok(insights);
     }
 
     // 인사이트 상세 페이지
     @GetMapping("/{insightId}")
-    public ResponseEntity<InsightResponseDto.InsightDetailRes> getInsightDetail(@PathVariable Long insightId) {
-        InsightResponseDto.InsightDetailRes insightDetail = insightService.getInsightDetail(insightId);
+    public ResponseEntity<InsightResponseDto.InsightDetailPageRes> getInsightDetail(@PathVariable Long insightId) {
+        InsightResponseDto.InsightDetailPageRes insightDetail = insightService.getInsightDetail(insightId);
         return ResponseEntity.ok(insightDetail);
     }
 

--- a/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
@@ -5,7 +5,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import zoo.insightnote.domain.insight.dto.InsightRequestDto;
 import zoo.insightnote.domain.insight.dto.InsightResponseDto;
+import zoo.insightnote.domain.insight.entity.Insight;
 import zoo.insightnote.domain.insight.service.InsightService;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -54,5 +58,37 @@ public class InsightControllerImpl implements InsightController{
         String message = result == 1 ? "좋아요가 등록되었습니다." : "좋아요가 취소되었습니다.";
         return ResponseEntity.ok(message);
     }
+
+
+
+    // 인기순위 상위 3개 가져오기
+    @GetMapping("/top")
+    public ResponseEntity<List<Insight>> getTop3Insights() {
+        List<Insight> insights = insightService.getTop3PopularInsights();
+        return ResponseEntity.ok(insights);
+    }
+
+    // 인사이트 목록 9개 기준 (시간순 정렬)
+    // 무한 스크롤 (페이징)
+
+    @GetMapping("/list")
+    public ResponseEntity<List<Insight>> getInsightsByEventDay(
+            @RequestParam("eventDay") LocalDate eventDay,
+            @RequestParam(value = "page", defaultValue = "0") int page) {
+        List<Insight> insights = insightService.getInsightsByEventDay(eventDay, page);
+        return ResponseEntity.ok(insights);
+    }
+
+    // 인사이트 상세 페이지
+
+
+
+
+
+
+
+
+
+
 
 }

--- a/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/controller/InsightControllerImpl.java
@@ -5,7 +5,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import zoo.insightnote.domain.insight.dto.InsightRequestDto;
 import zoo.insightnote.domain.insight.dto.InsightResponseDto;
-import zoo.insightnote.domain.insight.entity.Insight;
 import zoo.insightnote.domain.insight.service.InsightService;
 
 import java.time.LocalDate;

--- a/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
@@ -27,7 +27,7 @@ public class InsightResponseDto {
 
     @Getter
     @Builder
-    public static class InsightDetailRes {
+    public static class InsightDetailPageRes {
         private Long id;
         private String name;
         private String shortDescription;
@@ -47,7 +47,8 @@ public class InsightResponseDto {
     }
 
     @Getter
-    public static class InsightWithDetailsQueryDto {
+    @AllArgsConstructor
+    public static class InsightDetailQueryDto {
         private final Long id;
         private final String memo;
         private final String voteTitle;
@@ -64,31 +65,6 @@ public class InsightResponseDto {
         private final String keywords;
         private final String introductionLinks;
         private final Long likeCount;
-
-        public InsightWithDetailsQueryDto(
-                Long id, String memo, String voteTitle, Boolean isPublic, Boolean isAnonymous, Boolean isDraft,
-                Long sessionId, String sessionName, String sessionShortDescription,
-                Long userId, String userName, String email, String interestCategory,
-                String keywords, String introductionLinks,
-                Long likeCount
-        ) {
-            this.id = id;
-            this.memo = memo;
-            this.voteTitle = voteTitle;
-            this.isPublic = isPublic;
-            this.isAnonymous = isAnonymous;
-            this.isDraft = isDraft;
-            this.sessionId = sessionId;
-            this.sessionName = sessionName;
-            this.sessionShortDescription = sessionShortDescription;
-            this.userId = userId;
-            this.userName = userName;
-            this.email = email;
-            this.interestCategory = interestCategory;
-            this.keywords = keywords;
-            this.introductionLinks = introductionLinks;
-            this.likeCount = likeCount;
-        }
     }
 
 
@@ -108,8 +84,48 @@ public class InsightResponseDto {
 
     @Getter
     @AllArgsConstructor
+    public static class InsightListQueryDto {
+        private Long id;
+        private String memo;
+        private Boolean isPublic;
+        private Boolean isAnonymous;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+        private Long sessionId;
+        private String sessionName;
+        private Long likeCount;
+        private String latestImageUrl;
+        private String interestCategory;
+//
+//        public InsightListRes(
+//                Long id, String memo, Boolean isPublic, Boolean isAnonymous,
+//                LocalDateTime createdAt, LocalDateTime updatedAt,
+//                Long sessionId, String sessionName, Long likeCount,
+//                String latestImageUrl, String interestCategory) {
+//
+//            this.id = id;
+//            this.memo = memo;
+//            this.isPublic = isPublic;
+//            this.isAnonymous = isAnonymous;
+//            this.createdAt = createdAt;
+//            this.updatedAt = updatedAt;
+//            this.sessionId = sessionId;
+//            this.sessionName = sessionName;
+//            this.likeCount = likeCount;
+//            this.latestImageUrl = latestImageUrl;
+//            this.interestCategory = splitToList(interestCategory);
+//        }
+//
+//        private List<String> splitToList(String value) {
+//            if (value == null || value.isEmpty()) return List.of();
+//            return Arrays.asList(value.split("\\s*,\\s*")); // 쉼표 + 공백 제거하여 리스트 변환
+//        }
+    }
+
+    @Getter
+    @AllArgsConstructor
     @Builder
-    public static class InsightByEventDayRes {
+    public static class InsightListPageRes {
         private Long id;
         private String memo;
         private Boolean isPublic;
@@ -121,31 +137,5 @@ public class InsightResponseDto {
         private Long likeCount;
         private String latestImageUrl;
         private List<String> interestCategory;
-
-        // 문자열을 쉼표 기준으로 분리하는 생성자 추가
-        public InsightByEventDayRes(
-                Long id, String memo, Boolean isPublic, Boolean isAnonymous,
-                LocalDateTime createdAt, LocalDateTime updatedAt,
-                Long sessionId, String sessionName, Long likeCount,
-                String latestImageUrl, String interestCategory) {
-
-            this.id = id;
-            this.memo = memo;
-            this.isPublic = isPublic;
-            this.isAnonymous = isAnonymous;
-            this.createdAt = createdAt;
-            this.updatedAt = updatedAt;
-            this.sessionId = sessionId;
-            this.sessionName = sessionName;
-            this.likeCount = likeCount;
-            this.latestImageUrl = latestImageUrl;
-            this.interestCategory = splitToList(interestCategory);
-        }
-
-        // 문자열을 쉼표(`,`) 기준으로 List<String>으로 변환하는 메서드
-        private List<String> splitToList(String value) {
-            if (value == null || value.isEmpty()) return List.of();
-            return Arrays.asList(value.split("\\s*,\\s*")); // 쉼표 + 공백 제거하여 리스트 변환
-        }
     }
 }

--- a/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -87,6 +88,64 @@ public class InsightResponseDto {
             this.keywords = keywords;
             this.introductionLinks = introductionLinks;
             this.likeCount = likeCount;
+        }
+    }
+
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class InsightTopRes {
+        private Long id;
+        private String memo;
+        private Boolean isPublic;
+        private Boolean isAnonymous;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+        private Long likeCount;
+        private String imageUrl;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class InsightByEventDayRes {
+        private Long id;
+        private String memo;
+        private Boolean isPublic;
+        private Boolean isAnonymous;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+        private Long sessionId;
+        private String sessionName;
+        private Long likeCount;
+        private String latestImageUrl;
+        private List<String> interestCategory;
+
+        // 문자열을 쉼표 기준으로 분리하는 생성자 추가
+        public InsightByEventDayRes(
+                Long id, String memo, Boolean isPublic, Boolean isAnonymous,
+                LocalDateTime createdAt, LocalDateTime updatedAt,
+                Long sessionId, String sessionName, Long likeCount,
+                String latestImageUrl, String interestCategory) {
+
+            this.id = id;
+            this.memo = memo;
+            this.isPublic = isPublic;
+            this.isAnonymous = isAnonymous;
+            this.createdAt = createdAt;
+            this.updatedAt = updatedAt;
+            this.sessionId = sessionId;
+            this.sessionName = sessionName;
+            this.likeCount = likeCount;
+            this.latestImageUrl = latestImageUrl;
+            this.interestCategory = splitToList(interestCategory);
+        }
+
+        // 문자열을 쉼표(`,`) 기준으로 List<String>으로 변환하는 메서드
+        private List<String> splitToList(String value) {
+            if (value == null || value.isEmpty()) return List.of();
+            return Arrays.asList(value.split("\\s*,\\s*")); // 쉼표 + 공백 제거하여 리스트 변환
         }
     }
 }

--- a/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
@@ -33,6 +33,8 @@ public class InsightResponseDto {
         private String memo;
         private UserProfileDto profile;
         private Long likeCount;
+        private String voteTitle;
+        private List<VoteOptionDto> voteOptions;
 
         @Getter
         @Builder
@@ -44,26 +46,66 @@ public class InsightResponseDto {
         }
     }
 
+@Getter
+@AllArgsConstructor
+public static class InsightDetailQueryDto {
+    private Long id;
+    private String memo;
+    private String voteTitle;
+    private Boolean isPublic;
+    private Boolean isAnonymous;
+    private Boolean isDraft;
+    private Long sessionId;
+    private String sessionName;
+    private String sessionShortDescription;
+    private Long userId;
+    private String userName;
+    private String email;
+    private String interestCategory;
+    private String keywords;
+    private String introductionLinks;
+    private Long likeCount;
+    private List<VoteOptionDto> voteOptions;
+
+    // QueryDSL이 사용하는 생성자,  Projections.constructor()가 생성자를 찾지 못하기 때문에 별도로 표기함
+    // @AllArgsConstructor 있어도 해당 생성자 없으면 실행 오류나옴
+    public InsightDetailQueryDto(Long id, String memo, String voteTitle, Boolean isPublic, Boolean isAnonymous,
+                                 Boolean isDraft, Long sessionId, String sessionName, String sessionShortDescription,
+                                 Long userId, String userName, String email, String interestCategory, String keywords,
+                                 String introductionLinks, Long likeCount) {
+        this.id = id;
+        this.memo = memo;
+        this.voteTitle = voteTitle;
+        this.isPublic = isPublic;
+        this.isAnonymous = isAnonymous;
+        this.isDraft = isDraft;
+        this.sessionId = sessionId;
+        this.sessionName = sessionName;
+        this.sessionShortDescription = sessionShortDescription;
+        this.userId = userId;
+        this.userName = userName;
+        this.email = email;
+        this.interestCategory = interestCategory;
+        this.keywords = keywords;
+        this.introductionLinks = introductionLinks;
+        this.likeCount = likeCount;
+    }
+
+    // 투표 옵션 경우 쿼리에서 가져오는게 아니라 별도로 조회 후 추가하는 Setter 메서드
+    public void setVoteOptions(List<VoteOptionDto> voteOptions) {
+        this.voteOptions = voteOptions;
+    }
+}
+
+
     @Getter
     @AllArgsConstructor
-    public static class InsightDetailQueryDto {
-        private final Long id;
-        private final String memo;
-        private final String voteTitle;
-        private final Boolean isPublic;
-        private final Boolean isAnonymous;
-        private final Boolean isDraft;
-        private final Long sessionId;
-        private final String sessionName;
-        private final String sessionShortDescription;
-        private final Long userId;
-        private final String userName;
-        private final String email;
-        private final String interestCategory;
-        private final String keywords;
-        private final String introductionLinks;
-        private final Long likeCount;
+    public static class VoteOptionDto {
+        private Long optionId;
+        private String optionText;
+        private int voteCount;
     }
+
 
 
     @Getter

--- a/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
@@ -33,6 +33,7 @@ public class InsightResponseDto {
         private List<String> keywords;
         private String memo;
         private UserProfileDto profile;
+        private Long likeCount;
 
         @Getter
         @Builder
@@ -61,13 +62,14 @@ public class InsightResponseDto {
         private final String interestCategory;
         private final String keywords;
         private final String introductionLinks;
+        private final Long likeCount;
 
-        @Builder
         public InsightWithDetailsQueryDto(
                 Long id, String memo, String voteTitle, Boolean isPublic, Boolean isAnonymous, Boolean isDraft,
                 Long sessionId, String sessionName, String sessionShortDescription,
                 Long userId, String userName, String email, String interestCategory,
-                String keywords, String introductionLinks
+                String keywords, String introductionLinks,
+                Long likeCount
         ) {
             this.id = id;
             this.memo = memo;
@@ -84,6 +86,7 @@ public class InsightResponseDto {
             this.interestCategory = interestCategory;
             this.keywords = keywords;
             this.introductionLinks = introductionLinks;
+            this.likeCount = likeCount;
         }
     }
 }

--- a/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
@@ -4,9 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 
 public class InsightResponseDto {
@@ -96,36 +94,12 @@ public class InsightResponseDto {
         private Long likeCount;
         private String latestImageUrl;
         private String interestCategory;
-//
-//        public InsightListRes(
-//                Long id, String memo, Boolean isPublic, Boolean isAnonymous,
-//                LocalDateTime createdAt, LocalDateTime updatedAt,
-//                Long sessionId, String sessionName, Long likeCount,
-//                String latestImageUrl, String interestCategory) {
-//
-//            this.id = id;
-//            this.memo = memo;
-//            this.isPublic = isPublic;
-//            this.isAnonymous = isAnonymous;
-//            this.createdAt = createdAt;
-//            this.updatedAt = updatedAt;
-//            this.sessionId = sessionId;
-//            this.sessionName = sessionName;
-//            this.likeCount = likeCount;
-//            this.latestImageUrl = latestImageUrl;
-//            this.interestCategory = splitToList(interestCategory);
-//        }
-//
-//        private List<String> splitToList(String value) {
-//            if (value == null || value.isEmpty()) return List.of();
-//            return Arrays.asList(value.split("\\s*,\\s*")); // 쉼표 + 공백 제거하여 리스트 변환
-//        }
     }
 
     @Getter
     @AllArgsConstructor
     @Builder
-    public static class InsightListPageRes {
+    public static class InsightList {
         private Long id;
         private String memo;
         private Boolean isPublic;
@@ -138,4 +112,17 @@ public class InsightResponseDto {
         private String latestImageUrl;
         private List<String> interestCategory;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class InsightListPageRes {
+        private boolean hasNext;  // 다음 페이지 존재 여부
+        private long totalElements;  // 전체 데이터 개수
+        private int totalPages;  // 전체 페이지 개수
+        private int pageNumber;  // 현재 페이지 번호
+        private int pageSize;  // 페이지 크기
+        private List<InsightResponseDto.InsightList> content;  // 실제 데이터
+    }
+
 }

--- a/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/insight/dto/InsightResponseDto.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 public class InsightResponseDto {
 
@@ -22,4 +24,66 @@ public class InsightResponseDto {
         private LocalDateTime updatedAt;
     }
 
+    @Getter
+    @Builder
+    public static class InsightDetailRes {
+        private Long id;
+        private String name;
+        private String shortDescription;
+        private List<String> keywords;
+        private String memo;
+        private UserProfileDto profile;
+
+        @Getter
+        @Builder
+        public static class UserProfileDto {
+            private String name;
+            private String email;
+            private List<String> interestCategory;
+            private List<String> linkUrls;
+        }
+    }
+
+    @Getter
+    public static class InsightWithDetailsQueryDto {
+        private final Long id;
+        private final String memo;
+        private final String voteTitle;
+        private final Boolean isPublic;
+        private final Boolean isAnonymous;
+        private final Boolean isDraft;
+        private final Long sessionId;
+        private final String sessionName;
+        private final String sessionShortDescription;
+        private final Long userId;
+        private final String userName;
+        private final String email;
+        private final String interestCategory;
+        private final String keywords;
+        private final String introductionLinks;
+
+        @Builder
+        public InsightWithDetailsQueryDto(
+                Long id, String memo, String voteTitle, Boolean isPublic, Boolean isAnonymous, Boolean isDraft,
+                Long sessionId, String sessionName, String sessionShortDescription,
+                Long userId, String userName, String email, String interestCategory,
+                String keywords, String introductionLinks
+        ) {
+            this.id = id;
+            this.memo = memo;
+            this.voteTitle = voteTitle;
+            this.isPublic = isPublic;
+            this.isAnonymous = isAnonymous;
+            this.isDraft = isDraft;
+            this.sessionId = sessionId;
+            this.sessionName = sessionName;
+            this.sessionShortDescription = sessionShortDescription;
+            this.userId = userId;
+            this.userName = userName;
+            this.email = email;
+            this.interestCategory = interestCategory;
+            this.keywords = keywords;
+            this.introductionLinks = introductionLinks;
+        }
+    }
 }

--- a/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
+++ b/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
@@ -48,6 +48,7 @@ public class InsightMapper {
                 .shortDescription(insightDto.getSessionShortDescription())
                 .keywords(splitToList(insightDto.getKeywords()))  // 변환
                 .memo(insightDto.getMemo())
+                .likeCount(insightDto.getLikeCount())
                 .profile(InsightResponseDto.InsightDetailRes.UserProfileDto.builder()
                         .name(insightDto.getUserName())
                         .email(insightDto.getEmail())

--- a/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
+++ b/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
@@ -5,8 +5,10 @@ import zoo.insightnote.domain.insight.dto.InsightResponseDto;
 import zoo.insightnote.domain.insight.entity.Insight;
 import zoo.insightnote.domain.session.entity.Session;
 import zoo.insightnote.domain.user.entity.User;
+import zoo.insightnote.domain.userIntroductionLink.entity.UserIntroductionLink;
 import zoo.insightnote.domain.voteOption.entity.VoteOption;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -35,5 +37,27 @@ public class InsightMapper {
                 .createdAt(insight.getCreateAt())
                 .updatedAt(insight.getUpdatedAt())
                 .build();
+    }
+
+    public static InsightResponseDto.InsightDetailRes toDetailResponse(
+            InsightResponseDto.InsightWithDetailsQueryDto insightDto
+    ) {
+        return InsightResponseDto.InsightDetailRes.builder()
+                .id(insightDto.getId())
+                .name(insightDto.getSessionName())
+                .shortDescription(insightDto.getSessionShortDescription())
+                .keywords(splitToList(insightDto.getKeywords()))  // 변환
+                .memo(insightDto.getMemo())
+                .profile(InsightResponseDto.InsightDetailRes.UserProfileDto.builder()
+                        .name(insightDto.getUserName())
+                        .email(insightDto.getEmail())
+                        .interestCategory(splitToList(insightDto.getInterestCategory()))  // 변환
+                        .linkUrls(splitToList(insightDto.getIntroductionLinks()))  // 변환
+                        .build())
+                .build();
+    }
+
+    private static List<String> splitToList(String str) {
+        return (str != null && !str.isBlank()) ? Arrays.asList(str.split("\\s*,\\s*")) : List.of();
     }
 }

--- a/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
+++ b/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
@@ -5,8 +5,6 @@ import zoo.insightnote.domain.insight.dto.InsightResponseDto;
 import zoo.insightnote.domain.insight.entity.Insight;
 import zoo.insightnote.domain.session.entity.Session;
 import zoo.insightnote.domain.user.entity.User;
-import zoo.insightnote.domain.userIntroductionLink.entity.UserIntroductionLink;
-import zoo.insightnote.domain.voteOption.entity.VoteOption;
 
 import java.util.Arrays;
 import java.util.List;
@@ -39,30 +37,30 @@ public class InsightMapper {
                 .build();
     }
 
-    public static InsightResponseDto.InsightDetailRes toDetailResponse(
-            InsightResponseDto.InsightWithDetailsQueryDto insightDto
+    public static InsightResponseDto.InsightDetailPageRes toDetailPageResponse(
+            InsightResponseDto.InsightDetailQueryDto insightDto
     ) {
-        return InsightResponseDto.InsightDetailRes.builder()
+        return InsightResponseDto.InsightDetailPageRes.builder()
                 .id(insightDto.getId())
                 .name(insightDto.getSessionName())
                 .shortDescription(insightDto.getSessionShortDescription())
-                .keywords(splitToList(insightDto.getKeywords()))  // 변환
+                .keywords(splitToList(insightDto.getKeywords()))
                 .memo(insightDto.getMemo())
                 .likeCount(insightDto.getLikeCount())
-                .profile(InsightResponseDto.InsightDetailRes.UserProfileDto.builder()
+                .profile(InsightResponseDto.InsightDetailPageRes.UserProfileDto.builder()
                         .name(insightDto.getUserName())
                         .email(insightDto.getEmail())
-                        .interestCategory(splitToList(insightDto.getInterestCategory()))  // 변환
-                        .linkUrls(splitToList(insightDto.getIntroductionLinks()))  // 변환
+                        .interestCategory(splitToList(insightDto.getInterestCategory()))
+                        .linkUrls(splitToList(insightDto.getIntroductionLinks()))
                         .build())
                 .build();
     }
 
 
-    public static InsightResponseDto.InsightByEventDayRes toResponse(
-            InsightResponseDto.InsightByEventDayRes insightDto
+    public static InsightResponseDto.InsightListPageRes toListPageResponse (
+            InsightResponseDto.InsightListQueryDto insightDto
     ) {
-        return InsightResponseDto.InsightByEventDayRes.builder()
+        return InsightResponseDto.InsightListPageRes.builder()
                 .id(insightDto.getId())
                 .memo(insightDto.getMemo())
                 .isPublic(insightDto.getIsPublic())
@@ -73,8 +71,16 @@ public class InsightMapper {
                 .sessionName(insightDto.getSessionName())
                 .likeCount(insightDto.getLikeCount())
                 .latestImageUrl(insightDto.getLatestImageUrl())
-                .interestCategory(insightDto.getInterestCategory())
+                .interestCategory(splitToList(insightDto.getInterestCategory()))
                 .build();
+    }
+
+    public static List<InsightResponseDto.InsightListPageRes> toListPageResponse(
+            List<InsightResponseDto.InsightListQueryDto> insightDtos
+    ) {
+        return insightDtos.stream()
+                .map(InsightMapper::toListPageResponse)
+                .collect(Collectors.toList());
     }
 
 

--- a/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
+++ b/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
@@ -57,10 +57,10 @@ public class InsightMapper {
     }
 
 
-    public static InsightResponseDto.InsightListPageRes toListPageResponse (
+    public static InsightResponseDto.InsightList toListPageResponse (
             InsightResponseDto.InsightListQueryDto insightDto
     ) {
-        return InsightResponseDto.InsightListPageRes.builder()
+        return InsightResponseDto.InsightList.builder()
                 .id(insightDto.getId())
                 .memo(insightDto.getMemo())
                 .isPublic(insightDto.getIsPublic())
@@ -75,7 +75,7 @@ public class InsightMapper {
                 .build();
     }
 
-    public static List<InsightResponseDto.InsightListPageRes> toListPageResponse(
+    public static List<InsightResponseDto.InsightList> toListPageResponse(
             List<InsightResponseDto.InsightListQueryDto> insightDtos
     ) {
         return insightDtos.stream()

--- a/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
+++ b/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
@@ -53,6 +53,8 @@ public class InsightMapper {
                         .interestCategory(splitToList(insightDto.getInterestCategory()))
                         .linkUrls(splitToList(insightDto.getIntroductionLinks()))
                         .build())
+                .voteTitle(insightDto.getVoteTitle())
+                .voteOptions(insightDto.getVoteOptions())
                 .build();
     }
 

--- a/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
+++ b/src/main/java/zoo/insightnote/domain/insight/mapper/InsightMapper.java
@@ -58,6 +58,26 @@ public class InsightMapper {
                 .build();
     }
 
+
+    public static InsightResponseDto.InsightByEventDayRes toResponse(
+            InsightResponseDto.InsightByEventDayRes insightDto
+    ) {
+        return InsightResponseDto.InsightByEventDayRes.builder()
+                .id(insightDto.getId())
+                .memo(insightDto.getMemo())
+                .isPublic(insightDto.getIsPublic())
+                .isAnonymous(insightDto.getIsAnonymous())
+                .createdAt(insightDto.getCreatedAt())
+                .updatedAt(insightDto.getUpdatedAt())
+                .sessionId(insightDto.getSessionId())
+                .sessionName(insightDto.getSessionName())
+                .likeCount(insightDto.getLikeCount())
+                .latestImageUrl(insightDto.getLatestImageUrl())
+                .interestCategory(insightDto.getInterestCategory())
+                .build();
+    }
+
+
     private static List<String> splitToList(String str) {
         return (str != null && !str.isBlank()) ? Arrays.asList(str.split("\\s*,\\s*")) : List.of();
     }

--- a/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepository.java
+++ b/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepository.java
@@ -1,5 +1,7 @@
 package zoo.insightnote.domain.insight.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import zoo.insightnote.domain.insight.dto.InsightResponseDto;
 import zoo.insightnote.domain.insight.entity.Insight;
 
@@ -12,7 +14,7 @@ public interface InsightQueryRepository {
 
     List<InsightResponseDto.InsightTopRes> findTopInsights();
 
-    List<InsightResponseDto.InsightListQueryDto> findInsightsByEventDay(LocalDate eventDay, Integer offset, Integer limit);
+    Page<InsightResponseDto.InsightListQueryDto> findInsightsByEventDay(LocalDate eventDay, Pageable pageable);
 
     Optional<InsightResponseDto.InsightDetailQueryDto> findByIdWithSessionAndUser(Long insightId);
 }

--- a/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepository.java
+++ b/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepository.java
@@ -1,9 +1,11 @@
 package zoo.insightnote.domain.insight.repository;
 
+import zoo.insightnote.domain.insight.dto.InsightResponseDto;
 import zoo.insightnote.domain.insight.entity.Insight;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 
 public interface InsightQueryRepository {
@@ -11,4 +13,6 @@ public interface InsightQueryRepository {
     List<Insight> findTopInsights();
 
     List<Insight> findInsightsByEventDay(LocalDate eventDay, Integer offset, Integer limit);
+
+    Optional<InsightResponseDto.InsightWithDetailsQueryDto> findByIdWithSessionAndUser(Long insightId);
 }

--- a/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepository.java
+++ b/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepository.java
@@ -1,0 +1,14 @@
+package zoo.insightnote.domain.insight.repository;
+
+import zoo.insightnote.domain.insight.entity.Insight;
+
+import java.time.LocalDate;
+import java.util.List;
+
+
+public interface InsightQueryRepository {
+
+    List<Insight> findTopInsights();
+
+    List<Insight> findInsightsByEventDay(LocalDate eventDay, Integer offset, Integer limit);
+}

--- a/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepository.java
+++ b/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepository.java
@@ -12,7 +12,7 @@ public interface InsightQueryRepository {
 
     List<InsightResponseDto.InsightTopRes> findTopInsights();
 
-    List<InsightResponseDto.InsightByEventDayRes> findInsightsByEventDay(LocalDate eventDay, Integer offset, Integer limit);
+    List<InsightResponseDto.InsightListQueryDto> findInsightsByEventDay(LocalDate eventDay, Integer offset, Integer limit);
 
-    Optional<InsightResponseDto.InsightWithDetailsQueryDto> findByIdWithSessionAndUser(Long insightId);
+    Optional<InsightResponseDto.InsightDetailQueryDto> findByIdWithSessionAndUser(Long insightId);
 }

--- a/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepository.java
+++ b/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepository.java
@@ -10,9 +10,9 @@ import java.util.Optional;
 
 public interface InsightQueryRepository {
 
-    List<Insight> findTopInsights();
+    List<InsightResponseDto.InsightTopRes> findTopInsights();
 
-    List<Insight> findInsightsByEventDay(LocalDate eventDay, Integer offset, Integer limit);
+    List<InsightResponseDto.InsightByEventDayRes> findInsightsByEventDay(LocalDate eventDay, Integer offset, Integer limit);
 
     Optional<InsightResponseDto.InsightWithDetailsQueryDto> findByIdWithSessionAndUser(Long insightId);
 }

--- a/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepositoryImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepositoryImpl.java
@@ -4,6 +4,9 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import zoo.insightnote.domain.InsightLike.entity.QInsightLike;
 import zoo.insightnote.domain.insight.dto.InsightResponseDto;
 import zoo.insightnote.domain.insight.entity.QInsight;
@@ -53,14 +56,14 @@ public class InsightQueryRepositoryImpl implements InsightQueryRepository {
     }
 
     @Override
-    public List<InsightResponseDto.InsightListQueryDto> findInsightsByEventDay(LocalDate eventDay, Integer offset, Integer limit) {
+    public Page<InsightResponseDto.InsightListQueryDto> findInsightsByEventDay(LocalDate eventDay, Pageable pageable) {
         QInsight insight = QInsight.insight;
         QSession session = QSession.session;
         QInsightLike insightLike = QInsightLike.insightLike;
-//        QImage image = QImage.image; // 이미지 테이블 추가
         QUser user = QUser.user;
 
-        return queryFactory
+        // 데이터 조회
+        List<InsightResponseDto.InsightListQueryDto> insights = queryFactory
                 .select(Projections.constructor(
                         InsightResponseDto.InsightListQueryDto.class,
                         insight.id,
@@ -71,39 +74,42 @@ public class InsightQueryRepositoryImpl implements InsightQueryRepository {
                         insight.updatedAt,
                         session.id,
                         session.name,
-                        insightLike.id.count(),// 좋아요 개수
-
-                        //  최신 이미지 URL 가져오기 (서브쿼리)
+                        insightLike.id.count(), // 좋아요 개수
                         Expressions.stringTemplate(
                                 "(SELECT i.fileUrl FROM Image i " +
                                         "WHERE i.entityId = {0} AND i.entityType = 'INSIGHT' " +
                                         "ORDER BY i.createAt DESC, i.id DESC LIMIT 1)",
                                 insight.id
                         ).as("imageUrl"),
-//                        아래 해당 코드는 왜 서브쿼리 오류가 나는지 원인을 못찾음 : Subquery returns more than 1 row
-//                        JPAExpressions.select(image.fileUrl)
-//                                .from(image)
-//                                .where(image.entityId.eq(insight.id)
-//                                        .and(image.entityType.eq(EntityType.INSIGHT)))
-//                                .orderBy(image.createAt.desc(), image.id.desc()) // 최신순 정렬
-//                                .limit(1),
-
-
                         user.interestCategory
                 ))
                 .from(insight)
                 .join(insight.session, session)
-                .leftJoin(insightLike).on(insightLike.insight.eq(insight)) // 좋아요 카운트 추가
+                .leftJoin(insightLike).on(insightLike.insight.eq(insight))
                 .leftJoin(insight.user, user)
                 .where(
-                        session.eventDay.eq(eventDay), // 특정 날짜에 시작하는 세션
-                        insight.isDraft.eq(false) // 임시 저장된 인사이트 제외
+                        session.eventDay.eq(eventDay),
+                        insight.isDraft.eq(false)
                 )
-                .groupBy(insight.id, session.id, session.name, session.eventDay) //
-                .orderBy(insight.createAt.desc()) // 최신순 정렬
-                .offset(offset)
-                .limit(limit)
+                .groupBy(insight.id, session.id, session.name, session.eventDay)
+                .orderBy(insight.createAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
+
+        long totalElements = Optional.ofNullable(
+                queryFactory
+                        .select(insight.count())
+                        .from(insight)
+                        .join(insight.session, session)
+                        .where(
+                                session.eventDay.eq(eventDay),
+                                insight.isDraft.eq(false)
+                        )
+                        .fetchFirst()
+        ).orElse(0L);
+
+        return new PageImpl<>(insights, pageable, totalElements);
     }
 
     @Override

--- a/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepositoryImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepositoryImpl.java
@@ -66,6 +66,7 @@ public class InsightQueryRepositoryImpl implements InsightQueryRepository {
         QSessionKeyword sessionKeyword = QSessionKeyword.sessionKeyword;
         QKeyword keyword = QKeyword.keyword;
         QUserIntroductionLink introductionLink = QUserIntroductionLink.userIntroductionLink;
+        QInsightLike insightLike = QInsightLike.insightLike;
 
         return Optional.ofNullable(queryFactory
                 .select(Projections.constructor(
@@ -83,10 +84,9 @@ public class InsightQueryRepositoryImpl implements InsightQueryRepository {
                         user.name,
                         user.email,
                         user.interestCategory,
-                        // Group_Concat 사용 (키워드 리스트를 쉼표(,)로 구분하여 하나의 문자열로 변환)
                         Expressions.stringTemplate("GROUP_CONCAT(DISTINCT {0})", keyword.name),
-                        // Group_Concat 사용 (소개 링크 리스트를 쉼표(,)로 구분하여 하나의 문자열로 변환)
-                        Expressions.stringTemplate("GROUP_CONCAT(DISTINCT {0})", introductionLink.linkUrl)
+                        Expressions.stringTemplate("GROUP_CONCAT(DISTINCT {0})", introductionLink.linkUrl),
+                        insightLike.id.countDistinct()
                 ))
                 .from(insight)
                 .join(insight.session, session)
@@ -94,6 +94,7 @@ public class InsightQueryRepositoryImpl implements InsightQueryRepository {
                 .leftJoin(sessionKeyword).on(sessionKeyword.session.eq(session))
                 .leftJoin(sessionKeyword.keyword, keyword)
                 .leftJoin(introductionLink).on(introductionLink.user.eq(user))
+                .leftJoin(insightLike).on(insightLike.insight.eq(insight))
                 .where(insight.id.eq(insightId))
                 .groupBy(insight.id, session.id, user.id)
                 .fetchOne());

--- a/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepositoryImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepositoryImpl.java
@@ -1,0 +1,52 @@
+package zoo.insightnote.domain.insight.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import zoo.insightnote.domain.InsightLike.entity.QInsightLike;
+import zoo.insightnote.domain.insight.entity.Insight;
+import zoo.insightnote.domain.insight.entity.QInsight;
+import zoo.insightnote.domain.session.entity.QSession;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class InsightQueryRepositoryImpl implements InsightQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Insight> findTopInsights() {
+        QInsight insight = QInsight.insight;
+        QInsightLike insightLike = QInsightLike.insightLike;
+
+        return queryFactory
+                .select(insight)
+                .from(insight)
+                .leftJoin(insightLike).on(insightLike.insight.eq(insight)) // 좋아요 개수 세기
+                .groupBy(insight.id)
+                .orderBy(insightLike.id.count().desc(), insight.createAt.desc()) // 좋아요 개수 내림차순 -> 최신순 정렬
+                .limit(3)
+                .fetch();
+    }
+
+
+    @Override
+    public List<Insight> findInsightsByEventDay(LocalDate eventDay, Integer offset, Integer limit) {
+        QInsight insight = QInsight.insight;
+        QSession session = QSession.session;
+
+        return queryFactory
+                .select(insight)
+                .from(insight)
+                .join(insight.session, session)
+                .where(
+                        session.eventDay.eq(eventDay), // 특정 날짜에 시작하는 세션
+                        insight.isDraft.eq(false) // 임시 저장된 인사이트 제외
+                )
+                .orderBy(insight.createAt.desc()) // 최신순 정렬
+                .offset(offset)
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepositoryImpl.java
+++ b/src/main/java/zoo/insightnote/domain/insight/repository/InsightQueryRepositoryImpl.java
@@ -2,9 +2,12 @@ package zoo.insightnote.domain.insight.repository;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import zoo.insightnote.domain.InsightLike.entity.QInsightLike;
+import zoo.insightnote.domain.image.entity.EntityType;
+import zoo.insightnote.domain.image.entity.QImage;
 import zoo.insightnote.domain.insight.dto.InsightResponseDto;
 import zoo.insightnote.domain.insight.entity.Insight;
 import zoo.insightnote.domain.insight.entity.QInsight;
@@ -18,40 +21,83 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static zoo.insightnote.domain.user.entity.QUser.user;
+
 @RequiredArgsConstructor
 public class InsightQueryRepositoryImpl implements InsightQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Insight> findTopInsights() {
+    public List<InsightResponseDto.InsightTopRes> findTopInsights() {
         QInsight insight = QInsight.insight;
         QInsightLike insightLike = QInsightLike.insightLike;
 
         return queryFactory
-                .select(insight)
+                .select(Projections.constructor(
+                        InsightResponseDto.InsightTopRes.class,
+                        insight.id,
+                        insight.memo,
+                        insight.isPublic,
+                        insight.isAnonymous,
+                        insight.createAt,
+                        insight.updatedAt,
+                        insightLike.id.count(), // 좋아요 개수
+                        Expressions.stringTemplate(  // 최신 이미지 URL 가져오기
+                                "(SELECT i.fileUrl FROM Image i " +
+                                        "WHERE i.entityId = {0} AND i.entityType = 'INSIGHT' " +
+                                        "ORDER BY i.createAt DESC LIMIT 1)",
+                                insight.id
+                        ).as("imageUrl") // 서브쿼리 활용하여 최신 이미지 1개 가져오기
+                ))
                 .from(insight)
-                .leftJoin(insightLike).on(insightLike.insight.eq(insight)) // 좋아요 개수 세기
+                .leftJoin(insightLike).on(insightLike.insight.eq(insight))
                 .groupBy(insight.id)
-                .orderBy(insightLike.id.count().desc(), insight.createAt.desc()) // 좋아요 개수 내림차순 -> 최신순 정렬
+                .orderBy(insightLike.id.count().desc(), insight.createAt.desc())
                 .limit(3)
                 .fetch();
     }
 
-
     @Override
-    public List<Insight> findInsightsByEventDay(LocalDate eventDay, Integer offset, Integer limit) {
+    public List<InsightResponseDto.InsightByEventDayRes> findInsightsByEventDay(LocalDate eventDay, Integer offset, Integer limit) {
         QInsight insight = QInsight.insight;
         QSession session = QSession.session;
+        QInsightLike insightLike = QInsightLike.insightLike;
+//        QImage image = QImage.image; // 이미지 테이블 추가
+        QUser user = QUser.user;
 
         return queryFactory
-                .select(insight)
+                .select(Projections.constructor(
+                        InsightResponseDto.InsightByEventDayRes.class,
+                        insight.id,
+                        insight.memo,
+                        insight.isPublic,
+                        insight.isAnonymous,
+                        insight.createAt,
+                        insight.updatedAt,
+                        session.id,
+                        session.name,
+                        insightLike.id.count(),// 좋아요 개수
+
+                        //  최신 이미지 URL 가져오기 (서브쿼리)
+                        Expressions.stringTemplate(
+                                "(SELECT i.fileUrl FROM Image i " +
+                                        "WHERE i.entityId = {0} AND i.entityType = 'INSIGHT' " +
+                                        "ORDER BY i.createAt DESC, i.id DESC LIMIT 1)",
+                                insight.id
+                        ).as("imageUrl"),
+
+                        user.interestCategory
+                ))
                 .from(insight)
                 .join(insight.session, session)
+                .leftJoin(insightLike).on(insightLike.insight.eq(insight)) // 좋아요 카운트 추가
+                .leftJoin(insight.user, user)
                 .where(
                         session.eventDay.eq(eventDay), // 특정 날짜에 시작하는 세션
                         insight.isDraft.eq(false) // 임시 저장된 인사이트 제외
                 )
+                .groupBy(insight.id, session.id, session.name, session.eventDay) //
                 .orderBy(insight.createAt.desc()) // 최신순 정렬
                 .offset(offset)
                 .limit(limit)

--- a/src/main/java/zoo/insightnote/domain/insight/repository/InsightRepository.java
+++ b/src/main/java/zoo/insightnote/domain/insight/repository/InsightRepository.java
@@ -1,6 +1,8 @@
 package zoo.insightnote.domain.insight.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import zoo.insightnote.domain.insight.entity.Insight;
 import zoo.insightnote.domain.session.entity.Session;
 import zoo.insightnote.domain.user.entity.User;
@@ -10,4 +12,5 @@ import java.util.Optional;
 
 public interface InsightRepository extends JpaRepository<Insight, Long>, InsightQueryRepository {
     Optional<Insight> findBySessionAndUser(Session session, User user);
+
 }

--- a/src/main/java/zoo/insightnote/domain/insight/repository/InsightRepository.java
+++ b/src/main/java/zoo/insightnote/domain/insight/repository/InsightRepository.java
@@ -7,6 +7,7 @@ import zoo.insightnote.domain.user.entity.User;
 
 import java.util.Optional;
 
-public interface InsightRepository extends JpaRepository<Insight, Long> {
+
+public interface InsightRepository extends JpaRepository<Insight, Long>, InsightQueryRepository {
     Optional<Insight> findBySessionAndUser(Session session, User user);
 }

--- a/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
+++ b/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
@@ -168,16 +168,17 @@ public class InsightService {
 
     // 인기순위 상위 3개 가져오기
     @Transactional(readOnly = true)
-    public List<Insight> getTop3PopularInsights() {
+    public List<InsightResponseDto.InsightTopRes> getTopPopularInsights() {
         return insightRepository.findTopInsights();
     }
 
     // 인사이트 목록 9개 기준 (시간순 정렬)
     // 무한 스크롤 (페이징)
     @Transactional(readOnly = true)
-    public List<Insight> getInsightsByEventDay(LocalDate eventDay, int page) {
+    public List<InsightResponseDto.InsightByEventDayRes> getInsightsByEventDay(LocalDate eventDay, int page) {
         int pageSize = 9;
         int offset = page * pageSize;
+
         return insightRepository.findInsightsByEventDay(eventDay, offset, pageSize);
     }
 

--- a/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
+++ b/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
@@ -16,14 +16,18 @@ import zoo.insightnote.domain.insight.repository.InsightQueryRepository;
 import zoo.insightnote.domain.insight.repository.InsightRepository;
 import zoo.insightnote.domain.session.entity.Session;
 import zoo.insightnote.domain.session.repository.SessionRepository;
+import zoo.insightnote.domain.sessionKeyword.repository.SessionKeywordRepository;
 import zoo.insightnote.domain.user.entity.User;
 import zoo.insightnote.domain.user.repository.UserRepository;
+import zoo.insightnote.domain.userIntroductionLink.entity.UserIntroductionLink;
+import zoo.insightnote.domain.userIntroductionLink.repository.UserIntroductionLinkRepository;
 import zoo.insightnote.domain.voteOption.entity.VoteOption;
 import zoo.insightnote.domain.voteOption.repository.VoteOptionRepository;
 import zoo.insightnote.global.exception.CustomException;
 import zoo.insightnote.global.exception.ErrorCode;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -39,6 +43,8 @@ public class InsightService {
     private final ImageService imageService;
     private final UserRepository userRepository;
     private final VoteOptionRepository voteOptionRepository;
+    private final UserIntroductionLinkRepository userIntroductionLinkRepository;
+    private final SessionKeywordRepository sessionKeywordRepository;
 
     @Transactional
     public InsightResponseDto.InsightRes saveOrUpdateInsight(InsightRequestDto.CreateDto request) {
@@ -176,7 +182,15 @@ public class InsightService {
     }
 
     // 인사이트 상세 페이지
+    @Transactional(readOnly = true)
+    public InsightResponseDto.InsightDetailRes getInsightDetail(Long insightId) {
 
+        InsightResponseDto.InsightWithDetailsQueryDto insightDto = insightRepository.findByIdWithSessionAndUser(insightId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INSIGHT_NOT_FOUND));
+
+
+        return InsightMapper.toDetailResponse(insightDto);
+    }
 
 
 

--- a/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
+++ b/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
@@ -175,22 +175,28 @@ public class InsightService {
     // 인사이트 목록 9개 기준 (시간순 정렬)
     // 무한 스크롤 (페이징)
     @Transactional(readOnly = true)
-    public List<InsightResponseDto.InsightByEventDayRes> getInsightsByEventDay(LocalDate eventDay, int page) {
+    public List<InsightResponseDto.InsightListPageRes> getInsightsByEventDay(LocalDate eventDay, int page) {
         int pageSize = 9;
         int offset = page * pageSize;
 
-        return insightRepository.findInsightsByEventDay(eventDay, offset, pageSize);
+        List<InsightResponseDto.InsightListQueryDto> insightDtos = insightRepository.findInsightsByEventDay(eventDay, offset, pageSize);
+
+        if (insightDtos.isEmpty()) {
+            throw new CustomException(ErrorCode.INSIGHT_NOT_FOUND);
+        }
+
+        return InsightMapper.toListPageResponse(insightDtos);
+//        return insightRepository.findInsightsByEventDay(eventDay, offset, pageSize);
     }
 
     // 인사이트 상세 페이지
     @Transactional(readOnly = true)
-    public InsightResponseDto.InsightDetailRes getInsightDetail(Long insightId) {
+    public InsightResponseDto.InsightDetailPageRes getInsightDetail(Long insightId) {
 
-        InsightResponseDto.InsightWithDetailsQueryDto insightDto = insightRepository.findByIdWithSessionAndUser(insightId)
+        InsightResponseDto.InsightDetailQueryDto insightDto = insightRepository.findByIdWithSessionAndUser(insightId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INSIGHT_NOT_FOUND));
 
-
-        return InsightMapper.toDetailResponse(insightDto);
+        return InsightMapper.toDetailPageResponse(insightDto);
     }
 
 

--- a/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
+++ b/src/main/java/zoo/insightnote/domain/insight/service/InsightService.java
@@ -12,6 +12,7 @@ import zoo.insightnote.domain.insight.dto.InsightRequestDto;
 import zoo.insightnote.domain.insight.dto.InsightResponseDto;
 import zoo.insightnote.domain.insight.entity.Insight;
 import zoo.insightnote.domain.insight.mapper.InsightMapper;
+import zoo.insightnote.domain.insight.repository.InsightQueryRepository;
 import zoo.insightnote.domain.insight.repository.InsightRepository;
 import zoo.insightnote.domain.session.entity.Session;
 import zoo.insightnote.domain.session.repository.SessionRepository;
@@ -22,6 +23,7 @@ import zoo.insightnote.domain.voteOption.repository.VoteOptionRepository;
 import zoo.insightnote.global.exception.CustomException;
 import zoo.insightnote.global.exception.ErrorCode;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -32,10 +34,10 @@ import java.util.stream.Collectors;
 public class InsightService {
 
     private final InsightRepository insightRepository;
+    private final InsightLikeRepository insightLikeRepository;
     private final SessionRepository sessionRepository;
     private final ImageService imageService;
     private final UserRepository userRepository;
-    private final InsightLikeRepository insightLikeRepository;
     private final VoteOptionRepository voteOptionRepository;
 
     @Transactional
@@ -157,5 +159,25 @@ public class InsightService {
             return 1;
         }
     }
+
+    // 인기순위 상위 3개 가져오기
+    @Transactional(readOnly = true)
+    public List<Insight> getTop3PopularInsights() {
+        return insightRepository.findTopInsights();
+    }
+
+    // 인사이트 목록 9개 기준 (시간순 정렬)
+    // 무한 스크롤 (페이징)
+    @Transactional(readOnly = true)
+    public List<Insight> getInsightsByEventDay(LocalDate eventDay, int page) {
+        int pageSize = 9;
+        int offset = page * pageSize;
+        return insightRepository.findInsightsByEventDay(eventDay, offset, pageSize);
+    }
+
+    // 인사이트 상세 페이지
+
+
+
 
 }

--- a/src/main/java/zoo/insightnote/domain/userIntroductionLink/entity/UserIntroductionLink.java
+++ b/src/main/java/zoo/insightnote/domain/userIntroductionLink/entity/UserIntroductionLink.java
@@ -1,0 +1,34 @@
+package zoo.insightnote.domain.userIntroductionLink.entity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import zoo.insightnote.domain.user.entity.User;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class UserIntroductionLink {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 소개 링크 URL 또는 다른 관련 정보를 저장할 필드
+    private String linkUrl;
+
+    // 단방향 N:1 매핑 - 여러 개의 IntroductionLink가 하나의 User를 참조합니다.
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public UserIntroductionLink(String linkUrl, User user) {
+        this.linkUrl = linkUrl;
+        this.user = user;
+    }
+}

--- a/src/main/java/zoo/insightnote/domain/userIntroductionLink/repository/IntroductionLinkRepository.java
+++ b/src/main/java/zoo/insightnote/domain/userIntroductionLink/repository/IntroductionLinkRepository.java
@@ -1,0 +1,11 @@
+package zoo.insightnote.domain.userIntroductionLink.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import zoo.insightnote.domain.userIntroductionLink.entity.UserIntroductionLink;
+
+@Repository
+public interface IntroductionLinkRepository extends JpaRepository<UserIntroductionLink, Long> {
+
+}

--- a/src/main/java/zoo/insightnote/domain/userIntroductionLink/repository/UserIntroductionLinkRepository.java
+++ b/src/main/java/zoo/insightnote/domain/userIntroductionLink/repository/UserIntroductionLinkRepository.java
@@ -3,9 +3,12 @@ package zoo.insightnote.domain.userIntroductionLink.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import zoo.insightnote.domain.user.entity.User;
 import zoo.insightnote.domain.userIntroductionLink.entity.UserIntroductionLink;
 
-@Repository
-public interface IntroductionLinkRepository extends JpaRepository<UserIntroductionLink, Long> {
+import java.util.List;
 
+@Repository
+public interface UserIntroductionLinkRepository extends JpaRepository<UserIntroductionLink, Long> {
+    List<UserIntroductionLink> findByUser(User user);
 }


### PR DESCRIPTION
## Summary

>- close #69 

- 인사이트 상세 페이지에 들어가는 api를 구현
   - 인사이트 상세 관련 api 
   - 해당 인사이트 관련 댓글 가져오기 api 
- 인사이트 목록 페이지에 들어가는 api를 구현
   -  인사이트 인기순위 3개 목록 가져오는 api
   -  인사이트 페이징 api

## Tasks
- 더미데이터 삽입
- api 관련 쿼리 구현 
- 스웨거 테스트 (프론트 요청사항에 따라 출력되는지 확인)

## To Reviewer



## Screenshot
아래 부분에 해당하는 api 를 작업했습니다 
![스크린샷 2025-03-21 오전 9 37 58](https://github.com/user-attachments/assets/35b04c73-7185-4ad9-b7e2-c58d9b357349)
![스크린샷 2025-03-21 오전 9 37 49](https://github.com/user-attachments/assets/c535112e-77c3-40e2-919a-84c3079aebdb)

