### PR TITLE
[#86] JWTFilter 로그인과 상관관계 없게 수정

### DIFF
--- a/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.ProviderManager;
@@ -15,12 +16,10 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import zoo.insightnote.domain.user.service.CustomOAuth2UserService;
 import zoo.insightnote.domain.user.service.CustomUserDetailsService;
 import zoo.insightnote.global.jwt.GuestAuthenticationProvider;
@@ -105,15 +104,29 @@ public class SecurityConfig {
                 auth -> auth
                         //.requestMatchers("/api/v1/user/me").hasRole("USER")
                         //.requestMatchers("/api/v1/user/guest/me").hasRole("GUEST")
-                        .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/user/auth/token",
-                                "/actuator/**", "/api/v1/sessions/**", "/api/v1/speakers/**", "/api/v1/keywords/**",
-                                "/api/v1/user/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/sessions").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/sessions/*").permitAll()
+                        .requestMatchers(getPermitAllUris()).permitAll() // 모든 http 메소드 로그인 없이 접근 허용하는 경로
                         .anyRequest().authenticated());
 
         // 세션 설정 : STATELESS
         http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
+    }
+
+    // 로그인 없이 접근 가능한 경로
+    private String[] getPermitAllUris() {
+        return new String[] {
+                "/",
+                "/swagger-ui/**",
+                "/v3/api-docs/**",
+                "/user/auth/token",
+                "/actuator/**",
+                "/api/v1/speakers/**",
+                "/api/v1/keywords/**",
+                "/api/v1/user/**"
+        };
     }
 
 //    @Bean

--- a/src/main/java/zoo/insightnote/global/jwt/JWTFilter.java
+++ b/src/main/java/zoo/insightnote/global/jwt/JWTFilter.java
@@ -25,39 +25,45 @@ public class JWTFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        String requestURI = request.getRequestURI();
-        if (isIgnoredUri(requestURI)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+//        String requestURI = request.getRequestURI();
+//        if (isIgnoredUri(requestURI)) {
+//            filterChain.doFilter(request, response);
+//            return;
+//        }
 
         String token = getTokenFromRequest(request);
-        checkAuthorization(request, response, filterChain, token);
-        checkToken(request, response, filterChain, token);
+        //checkAuthorization(request, response, filterChain, token);
+        //checkToken(request, response, filterChain, token);
 
-        String username = jwtUtil.getUsername(token);
-        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
-        Authentication authToken = new UsernamePasswordAuthenticationToken(userDetails, null,
-                userDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(authToken);
+        if(token != null) {
+            if(jwtUtil.isExpired(token)) {
+                throw new AuthenticationException("token expired") {
+                };
+            }
+            String username = jwtUtil.getUsername(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+            Authentication authToken = new UsernamePasswordAuthenticationToken(userDetails, null,
+                    userDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
 
         filterChain.doFilter(request, response);
     }
 
-    private boolean isIgnoredUri(String uri) {
-        return uri.startsWith("/swagger-ui")
-                || uri.startsWith("/v3/api-docs")
-                || uri.startsWith("/actuator")
-                || uri.startsWith("/favicon.ico")
-                || uri.startsWith("/login")
-                || uri.equals("/api/v1/sessions")
-                || uri.equals("/api/v1/sessions/{sessionId}")
-                || uri.equals("/api/v1/sessions/detailed")
-                || uri.startsWith("/api/v1/speakers")
-                || uri.startsWith("/api/v1/keywords")
-                || uri.startsWith("/api/v1/user/join")
-                || uri.startsWith("/api/v1/user/login");
-    }
+//    private boolean isIgnoredUri(String uri) {
+//        return uri.startsWith("/swagger-ui")
+//                || uri.startsWith("/v3/api-docs")
+//                || uri.startsWith("/actuator")
+//                || uri.startsWith("/favicon.ico")
+//                || uri.startsWith("/login")
+//                || uri.equals("/api/v1/sessions")
+//                || uri.equals("/api/v1/sessions/{sessionId}")
+//                || uri.equals("/api/v1/sessions/detailed")
+//                || uri.startsWith("/api/v1/speakers")
+//                || uri.startsWith("/api/v1/keywords")
+//                || uri.startsWith("/api/v1/user/join")
+//                || uri.startsWith("/api/v1/user/login");
+//    }
 
     private String getTokenFromRequest(HttpServletRequest request) {
         String headerToken = request.getHeader("Authorization");
@@ -78,19 +84,19 @@ public class JWTFilter extends OncePerRequestFilter {
         return null;
     }
 
-    private void checkToken(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain,
-                            String token) throws IOException, ServletException {
-        if (jwtUtil.isExpired(token)) {
-            throw new AuthenticationException("token expired") {
-            };
-        }
-    }
-
-    private void checkAuthorization(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain,
-                                    String authorization) throws IOException, ServletException {
-        if (authorization == null) {
-            throw new AuthenticationException("token null") {
-            };
-        }
-    }
+//    private void checkToken(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain,
+//                            String token) throws IOException, ServletException {
+//        if (jwtUtil.isExpired(token)) {
+//            throw new AuthenticationException("token expired") {
+//            };
+//        }
+//    }
+//
+//    private void checkAuthorization(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain,
+//                                    String authorization) throws IOException, ServletException {
+//        if (authorization == null) {
+//            throw new AuthenticationException("token null") {
+//            };
+//        }
+//    }
 }


### PR DESCRIPTION
## Summary

>- 관련 있는 Issue를 태그해주세요.

#86 
closed #86 

- api 호출시 로그인 하지 않으면 JWTFilter에서 token = null 예외 처리 발생하여서 문제가 생김

## Tasks

- JWTFilter에서 토큰이 있을 때는 유저 정보 추출하고 토큰이 없을 때에는 예외처리 없이 정상 작동 하도록 수정
- SecurityConfig의 경로별 인가 작업 수정
