### PR TITLE
[#89] 비회원 회원가입과 로그인 api 하나로 통일

### DIFF
--- a/src/main/java/zoo/insightnote/domain/email/service/EmailService.java
+++ b/src/main/java/zoo/insightnote/domain/email/service/EmailService.java
@@ -1,8 +1,10 @@
 package zoo.insightnote.domain.email.service;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,11 +13,26 @@ public class EmailService {
 
     private final JavaMailSender mailSender;
 
-    public void sendVerificationCode(String email, String code) {
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(email);
-        message.setSubject("[인사이트 노트] 인증코드입니다.");
-        message.setText("인증코드 :  " + code);
-        mailSender.send(message);
+    public void sendVerificationCode(String email, String code) throws MessagingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "utf-8");
+
+        String htmlMsg = "<html>" +
+                "<body>" +
+                "안녕하세요, <strong>Synapse X</strong>입니다.<br><br>" +
+                "아래는 요청하신 인증코드입니다.<br>" +
+                "본인을 확인하기 위해 다음 코드를 입력해 주세요.<br><br>" +
+                "<strong><u>인증코드</u> : " + code + "</strong><br><br>" +
+                "해당 인증코드는 <strong>5분간 유효</strong>합니다.<br>" +
+                "본인이 아닌 분이 해당 이메일을 받았다면, 인증코드를 사용하지 마시고 즉시 삭제해 주세요.<br>" +
+                "감사합니다.<br><br><br>" +
+                "<strong>Synapse X</strong> 드림" +
+                "</body>" +
+                "</html>";
+
+        helper.setTo(email);
+        helper.setSubject("[Synapse X] 인증코드 안내");
+        helper.setText(htmlMsg, true);
+        mailSender.send(mimeMessage);
     }
 }

--- a/src/main/java/zoo/insightnote/domain/email/service/EmailVerificationService.java
+++ b/src/main/java/zoo/insightnote/domain/email/service/EmailVerificationService.java
@@ -1,5 +1,6 @@
 package zoo.insightnote.domain.email.service;
 
+import jakarta.mail.MessagingException;
 import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,7 @@ public class EmailVerificationService {
     private final EmailService emailService;
     private final StringRedisTemplate redisTemplate;
 
-    public void sendVerificationCode(String email) {
+    public void sendVerificationCode(String email) throws MessagingException {
         redisTemplate.delete(email);
 
         SecureRandom secureRandom = new SecureRandom();

--- a/src/main/java/zoo/insightnote/domain/user/controller/UserController.java
+++ b/src/main/java/zoo/insightnote/domain/user/controller/UserController.java
@@ -3,14 +3,13 @@ package zoo.insightnote.domain.user.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.Valid;
 import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import zoo.insightnote.domain.email.dto.request.EmailAuthRequest;
 import zoo.insightnote.domain.user.dto.request.JoinRequest;
@@ -26,7 +25,7 @@ public interface UserController {
     ResponseEntity<?> login(@Parameter(description = "이메일, 이메일 기입") @RequestBody JoinRequest joinRequest);
 
     @Operation(summary = "비회원 이메일 인증", description = "비회원 회원가입과 로그인을 위한 로그인 인증입니다. 전송 시 5분간 유효합니다. (코드 전송은 약 4초 정도 소요되니 잠시만 기다려주세요.)")
-    public ResponseEntity<?> sendEmailAuthCode(@Parameter(description = "인증할 이메일 기입") @RequestBody EmailAuthRequest emailAuthRequest);
+    public ResponseEntity<?> sendEmailAuthCode(@Parameter(description = "인증할 이메일 기입") @RequestBody EmailAuthRequest emailAuthRequest) throws MessagingException;
 
     @Operation(summary = "토큰 기반 본인 확인", description = "토큰에 저장된 username을 반환합니다.")
     ResponseEntity<?> getMyInfo(@AuthenticationPrincipal UserDetails userDetails);

--- a/src/main/java/zoo/insightnote/domain/user/controller/UserController.java
+++ b/src/main/java/zoo/insightnote/domain/user/controller/UserController.java
@@ -18,8 +18,8 @@ import zoo.insightnote.domain.user.dto.PaymentUserInfoResponseDto;
 @Tag(name = "USER", description = "유저 관련 API")
 public interface UserController {
 
-    @Operation(summary = "비회원 회원가입", description = "이메일 인증 후 비회원 회원가입을 진행합니다.")
-    ResponseEntity<?> joinProcess(@Parameter(description = "이름, 이메일 기입")@RequestBody JoinRequest joinRequest);
+//    @Operation(summary = "비회원 회원가입", description = "이메일 인증 후 비회원 회원가입을 진행합니다.")
+//    ResponseEntity<?> joinProcess(@Parameter(description = "이름, 이메일 기입")@RequestBody JoinRequest joinRequest);
 
     @Operation(summary = "비회원 로그인", description = "이메일 인증 후 비회원 로그인을 진행합니다.")
     ResponseEntity<?> login(@Parameter(description = "이메일, 이메일 기입") @RequestBody JoinRequest joinRequest);

--- a/src/main/java/zoo/insightnote/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/user/controller/UserControllerImpl.java
@@ -33,11 +33,11 @@ public class UserControllerImpl implements UserController {
     private final UserService userService;
     private final EmailVerificationService emailVerificationService;
 
-    @PostMapping("/join")
-    public ResponseEntity<?> joinProcess(@Valid @RequestBody JoinRequest joinRequest) {
-        userService.joinProcess(joinRequest);
-        return ResponseEntity.ok().build();
-    }
+//    @PostMapping("/join")
+//    public ResponseEntity<?> joinProcess(@Valid @RequestBody JoinRequest joinRequest) {
+//        userService.joinProcess(joinRequest);
+//        return ResponseEntity.ok().build();
+//    }
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody JoinRequest joinRequest) {

--- a/src/main/java/zoo/insightnote/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/user/controller/UserControllerImpl.java
@@ -1,5 +1,6 @@
 package zoo.insightnote.domain.user.controller;
 
+import jakarta.mail.MessagingException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -44,7 +45,7 @@ public class UserControllerImpl implements UserController {
     }
 
     @PostMapping("/email-auth")
-    public ResponseEntity<?> sendEmailAuthCode(@Valid @RequestBody EmailAuthRequest emailAuthRequest) {
+    public ResponseEntity<?> sendEmailAuthCode(@Valid @RequestBody EmailAuthRequest emailAuthRequest) throws MessagingException {
         emailVerificationService.sendVerificationCode(emailAuthRequest.getEmail());
         return ResponseEntity.ok("인증코드를 전송했습니다");
     }

--- a/src/main/java/zoo/insightnote/domain/user/service/UserService.java
+++ b/src/main/java/zoo/insightnote/domain/user/service/UserService.java
@@ -2,14 +2,17 @@ package zoo.insightnote.domain.user.service;
 
 import static zoo.insightnote.domain.user.entity.Role.*;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import zoo.insightnote.domain.email.service.EmailVerificationService;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import zoo.insightnote.domain.payment.dto.etc.UserInfoDto;
+import zoo.insightnote.domain.user.dto.CustomUserDetails;
 import zoo.insightnote.domain.user.dto.request.JoinRequest;
 import zoo.insightnote.domain.user.dto.PaymentUserInfoResponseDto;
+import zoo.insightnote.domain.user.entity.Role;
 import zoo.insightnote.domain.user.entity.User;
 import zoo.insightnote.domain.user.repository.UserRepository;
 import zoo.insightnote.global.exception.CustomException;
@@ -22,23 +25,19 @@ public class UserService {
     private final UserRepository userRepository;
     private final EmailVerificationService emailVerificationService;
 
-    @Transactional
-    public void joinProcess(JoinRequest joinRequest) {
-
-        String name = joinRequest.getName();
-        String email = joinRequest.getEmail();
-        String code = joinRequest.getCode();
-
+    public void autoRegisterAndLogin(String name, String email, String code) {
         verifyCode(email, code);
-        existUser(email);
 
-        User user = User.builder()
-                .name(name)
-                .email(email)
-                .role(GUEST)
-                .username(email)
-                .build();
-        userRepository.save(user);
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+        if (!optionalUser.isPresent()) {
+            User user = User.builder()
+                    .name(name)
+                    .email(email)
+                    .username(email)
+                    .role(Role.GUEST)
+                    .build();
+            userRepository.save(user);
+        }
     }
 
     private void verifyCode(String email, String code) {

--- a/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
+++ b/src/main/java/zoo/insightnote/global/config/SecurityConfig.java
@@ -20,9 +20,9 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
-import zoo.insightnote.domain.email.service.EmailVerificationService;
 import zoo.insightnote.domain.user.service.CustomOAuth2UserService;
 import zoo.insightnote.domain.user.service.CustomUserDetailsService;
+import zoo.insightnote.domain.user.service.UserService;
 import zoo.insightnote.global.jwt.GuestAuthenticationProvider;
 import zoo.insightnote.global.jwt.GuestLoginFilter;
 import zoo.insightnote.global.jwt.JWTFilter;
@@ -42,7 +42,7 @@ public class SecurityConfig {
     private final JWTUtil jwtUtil;
     private final CustomUserDetailsService userDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
-    private final EmailVerificationService emailVerificationService;
+    private final UserService userService;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -91,7 +91,7 @@ public class SecurityConfig {
 
         // JWT 필터 추가
         http
-                .addFilterAt(new GuestLoginFilter("/api/v1/user/login", customAuthenticationManager(), jwtUtil, emailVerificationService),
+                .addFilterAt(new GuestLoginFilter("/api/v1/user/login", customAuthenticationManager(), jwtUtil, userService),
                         UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JWTFilter(jwtUtil, userDetailsService), GuestLoginFilter.class);
 

--- a/src/main/java/zoo/insightnote/global/jwt/GuestLoginFilter.java
+++ b/src/main/java/zoo/insightnote/global/jwt/GuestLoginFilter.java
@@ -14,23 +14,21 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
-import zoo.insightnote.domain.email.service.EmailVerificationService;
 import zoo.insightnote.domain.user.dto.CustomUserDetails;
-import zoo.insightnote.global.exception.CustomException;
-import zoo.insightnote.global.exception.ErrorCode;
+import zoo.insightnote.domain.user.service.UserService;
 
 public class GuestLoginFilter extends AbstractAuthenticationProcessingFilter {
 
     private final JWTUtil jwtUtil;
-    private final EmailVerificationService emailVerificationService;
+    private final UserService userService;
 
     private static final long EXPIRATION_TIME = 10 * 60 * 60 * 1000L; // 10시간 (refresh token 적용시 변경 예정)
 
-    public GuestLoginFilter(String defaultFilterProcessesUrl, AuthenticationManager authenticationManager, JWTUtil jwtUtil, EmailVerificationService emailVerificationService) {
+    public GuestLoginFilter(String defaultFilterProcessesUrl, AuthenticationManager authenticationManager, JWTUtil jwtUtil, UserService userService) {
         super(defaultFilterProcessesUrl);
         setAuthenticationManager(authenticationManager);
         this.jwtUtil = jwtUtil;
-        this.emailVerificationService = emailVerificationService;
+        this.userService = userService;
     }
 
     @Override
@@ -53,9 +51,7 @@ public class GuestLoginFilter extends AbstractAuthenticationProcessingFilter {
         name = name.trim();
         email = email.trim();
 
-        if (code == null || code.isBlank() || !emailVerificationService.verifyCode(email, code)) {
-            throw new CustomException(ErrorCode.INVALID_VERIFICATION_CODE);
-        }
+        userService.autoRegisterAndLogin(name, email, code);
 
         GuestAuthenticationToken authRequest = new GuestAuthenticationToken(name, email);
         authRequest.setDetails(authenticationDetailsSource.buildDetails(request));


### PR DESCRIPTION
## Summary

#89 
closed #89 

**해당 PR에 대한 요약을 작성해주세요.**

## Tasks

- 인증번호 전송 이메일 텍스트 수정
- 비회원 회원가입과 로그인 로직 하나로 통일(프론트 쪽에서 회원가입과 로그인 로직이 따로 없음.)

## Screenshot
![image](https://github.com/user-attachments/assets/9839d292-f89d-4b9a-98b1-6a7650bb1741)
