### PR TITLE
[#116] refactor : Comment 도메인 코드 리팩토링

### DIFF
--- a/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
@@ -1,11 +1,9 @@
 package zoo.insightnote.domain.comment.controller;
 
-import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,12 +39,6 @@ public class CommentControllerImpl implements CommentController {
         return ResponseEntity.ok().body(commentId);
     }
 
-//    @Override
-//    @GetMapping("/{insightId}/comments")
-//    public ResponseEntity<List<CommentResponse>> listComments(@PathVariable Long insightId) {
-//        return ResponseEntity.ok().body(commentService.findCommentsByInsightId(insightId));
-//    }
-
     @Override
     @PutMapping("/{insightId}/comments/{commentId}")
     public ResponseEntity<CommentIdResDto> updateComment(@PathVariable Long insightId,
@@ -67,15 +59,6 @@ public class CommentControllerImpl implements CommentController {
         commentService.deleteComment(insightId, userDetails.getUsername(), commentId);
         return ResponseEntity.noContent().build();
     }
-
-    // 임시 로직
-    private UserDetails validateUser(UserDetails userDetails) {
-        if (userDetails != null) {
-            return userDetails;
-        }
-        return new User("001", "password", Collections.emptyList());
-    }
-
 
     // 댓글 리스트 출력
     @Override

--- a/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/comment/controller/CommentControllerImpl.java
@@ -33,18 +33,19 @@ public class CommentControllerImpl implements CommentController {
     public ResponseEntity<CommentIdResDto> writeComment(
             @PathVariable Long insightId,
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestBody CommentCreateReqDto request)
-    {
+            @RequestBody CommentCreateReqDto request) {
         CommentIdResDto commentId = commentService.createComment(insightId, userDetails.getUsername(), request);
         return ResponseEntity.ok().body(commentId);
     }
 
     @Override
     @PutMapping("/{insightId}/comments/{commentId}")
-    public ResponseEntity<CommentIdResDto> updateComment(@PathVariable Long insightId,
-                                                         @PathVariable Long commentId,
-                                                         @AuthenticationPrincipal UserDetails userDetails,
-                                                         @RequestBody CommentUpdateReqDto request) {
+    public ResponseEntity<CommentIdResDto> updateComment(
+            @PathVariable Long insightId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody CommentUpdateReqDto request
+    ) {
         CommentIdResDto response = commentService.updateComment(insightId, userDetails.getUsername(), commentId, request);
         return ResponseEntity.ok().body(response);
     }
@@ -54,13 +55,11 @@ public class CommentControllerImpl implements CommentController {
     public ResponseEntity<Void> deleteComment(
             @PathVariable Long insightId,
             @PathVariable Long commentId,
-            @AuthenticationPrincipal UserDetails userDetails)
-    {
+            @AuthenticationPrincipal UserDetails userDetails) {
         commentService.deleteComment(insightId, userDetails.getUsername(), commentId);
         return ResponseEntity.noContent().build();
     }
 
-    // 댓글 리스트 출력
     @Override
     @GetMapping("/comments/{insightId}")
     public ResponseEntity<List<CommentListResDto>> getListComments(@PathVariable Long insightId) {

--- a/src/main/java/zoo/insightnote/domain/comment/entity/Comment.java
+++ b/src/main/java/zoo/insightnote/domain/comment/entity/Comment.java
@@ -27,14 +27,12 @@ public class Comment extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //TODO : user Entity 개발 완료시 nullable = false로 수정
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = true)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    //TODO : insight Entity 개발 완료시 nullable = false로 수정
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "insight_id", nullable = true)
+    @JoinColumn(name = "insight_id", nullable = false)
     private Insight insight;
 
     private String content;

--- a/src/main/java/zoo/insightnote/domain/comment/service/CommentService.java
+++ b/src/main/java/zoo/insightnote/domain/comment/service/CommentService.java
@@ -18,6 +18,7 @@ import zoo.insightnote.domain.comment.mapper.CommentMapper;
 import zoo.insightnote.domain.comment.repository.CommentRepository;
 import zoo.insightnote.domain.insight.entity.Insight;
 import zoo.insightnote.domain.insight.repository.InsightRepository;
+import zoo.insightnote.domain.insight.service.InsightService;
 import zoo.insightnote.domain.user.entity.User;
 import zoo.insightnote.domain.user.repository.UserRepository;
 import zoo.insightnote.domain.user.service.UserService;
@@ -35,7 +36,7 @@ public class CommentService {
     public CommentIdResDto createComment(Long insightId, String userName, CommentCreateReqDto request) {
 
         Insight insight = insightRepository.findById(insightId)
-                .orElseThrow(() -> new CustomException(null, "인사이트 노트를 찾을 수 없음"));
+                .orElseThrow(() -> new CustomException(ErrorCode.INSIGHT_NOT_FOUND));
 
         User user = userService.findByUsername(userName);
 
@@ -45,18 +46,6 @@ public class CommentService {
 
         return new CommentIdResDto(comment.getId());
     }
-
-//    public List<CommentResponse> findCommentsByInsightId(Long insightId) {
-//
-//        List<Comment> comments = commentRepository.findAllByInsightId(insightId);
-//
-//        List<CommentResponse> responses = new ArrayList<>();
-//        for (Comment comment : comments) {
-//            responses.add(CommentMapper.toResponse(comment));
-//        }
-//
-//        return responses;
-//    }
 
     @Transactional
     public CommentIdResDto updateComment(Long insightId, String userName, Long commentId, CommentUpdateReqDto request) {


### PR DESCRIPTION
## Summary

>- #116 
>- closes #116 

`Comment` 엔티티 내부에 위치하는 `insight` `user` 필드에 제약 조건 추가 및 코드 리팩토링

## Tasks

- Comment.java insight, user 제약 조건 추가
- CommentController 리팩토링
- CommentServer 리팩토링

## To Reviewer

현재 `CommentService` 클래스 내부에 댓글을 생성하는 `createComment()` 메서드 내부에서 `insightRepository`에 직접 접근하여 인사트를 찾아오고 예외 처리까지 함께 담당하고 있습니다.

 리팩토링 과정에서 `InsightServer`에서 `insight`를 받아오려고 하였지만 메서드가 존재하지 않아 그대로 남겨놓았습니다. 이 부분은 `InsightService`에서 직접 담당하는것이 객체지향적인 코드라고 생각하는데 어떻게 생각하는지 궁금합니다!
