### PR TITLE
[#113] 내 세션 리스트 API 구현

### DIFF
--- a/src/main/java/zoo/insightnote/domain/payment/controller/PaymentController.java
+++ b/src/main/java/zoo/insightnote/domain/payment/controller/PaymentController.java
@@ -27,7 +27,10 @@ public interface PaymentController {
             }
     )
     @PostMapping("/request")
-    ResponseEntity<KakaoPayReadyResponseDto> requestPayment(@RequestBody PaymentRequestReadyDto request);
+    ResponseEntity<KakaoPayReadyResponseDto> requestPayment(
+            @RequestBody PaymentRequestReadyDto request,
+            @AuthenticationPrincipal UserDetails userDetails
+    );
 
     @Operation(
             summary = "결제 승인 API",

--- a/src/main/java/zoo/insightnote/domain/payment/controller/PaymentControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/payment/controller/PaymentControllerImpl.java
@@ -12,6 +12,8 @@ import zoo.insightnote.domain.payment.dto.response.KakaoPayApproveResponseDto;
 import zoo.insightnote.domain.payment.dto.response.KakaoPayReadyResponseDto;
 import zoo.insightnote.domain.payment.service.KakaoPayService;
 import zoo.insightnote.domain.payment.service.PaymentService;
+import zoo.insightnote.domain.user.entity.User;
+import zoo.insightnote.domain.user.service.UserService;
 
 @RestController
 @RequestMapping("/api/v1/payment")
@@ -19,12 +21,15 @@ import zoo.insightnote.domain.payment.service.PaymentService;
 public class PaymentControllerImpl implements PaymentController {
     private final KakaoPayService kakaoPayService;
     private final PaymentService paymentService;
+    private final UserService userService;
 
     // 주문 정보를 가지고 카카오페이 API에 결제 요청
     @PostMapping("/request")
     public ResponseEntity<KakaoPayReadyResponseDto> requestPayment(
-            @RequestBody @Valid PaymentRequestReadyDto requestDto) {
-        return kakaoPayService.requestKakaoPayment(requestDto);
+            @RequestBody @Valid PaymentRequestReadyDto requestDto,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        User user = userService.findByUsername(userDetails.getUsername());
+        return kakaoPayService.requestKakaoPayment(requestDto, user);
     }
 
     // 카카오페이 API에서 결제 요청 승인

--- a/src/main/java/zoo/insightnote/domain/payment/dto/request/PaymentRequestReadyDto.java
+++ b/src/main/java/zoo/insightnote/domain/payment/dto/request/PaymentRequestReadyDto.java
@@ -14,9 +14,6 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class PaymentRequestReadyDto {
-    @NotNull
-    private Long userId;
-
     @NotBlank
     private String itemName;
 

--- a/src/main/java/zoo/insightnote/domain/payment/service/PaymentService.java
+++ b/src/main/java/zoo/insightnote/domain/payment/service/PaymentService.java
@@ -39,10 +39,10 @@ public class PaymentService {
         String tid = paymentRedisService.getTidKey(requestDto.getOrderId());
         List<Long> sessionIds = paymentRedisService.getSessionIds(requestDto.getOrderId());
         UserInfoDto userInfo = paymentRedisService.getUserInfo(requestDto.getOrderId());
+        User user = userService.findByUsername(requestDto.getUsername());
 
-        KakaoPayApproveResponseDto response = kakaoPayService.approveKakaoPayment(tid, requestDto);
+        KakaoPayApproveResponseDto response = kakaoPayService.approveKakaoPayment(tid, requestDto, user);
         try {
-            User user = userService.findByUsername(requestDto.getUsername());
             savePaymentInfo(response, sessionIds.get(0), user, tid, userInfo.isOnline());
             saveReservationsInfo(sessionIds, user);
             userService.updateUserInfo(userInfo, user);

--- a/src/main/java/zoo/insightnote/domain/reservation/dto/response/UserTicketInfoResponseDto.java
+++ b/src/main/java/zoo/insightnote/domain/reservation/dto/response/UserTicketInfoResponseDto.java
@@ -21,7 +21,9 @@ public class UserTicketInfoResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class reservationSessions {
-        private String timeRange;
         private Long sessionId;
+        private String sessionName;
+        private String speakerName;
+        private String timeRange;
     }
 }

--- a/src/main/java/zoo/insightnote/domain/reservation/repository/ReservationCustomQueryRepository.java
+++ b/src/main/java/zoo/insightnote/domain/reservation/repository/ReservationCustomQueryRepository.java
@@ -22,7 +22,6 @@ import java.util.*;
 @Slf4j
 public class ReservationCustomQueryRepository {
     private final JPAQueryFactory queryFactory;
-    private final SpeakerService speakerService;
 
     public List<Tuple> findUserReservationInfo(String username) {
         QReservation reservation = QReservation.reservation;


### PR DESCRIPTION
## Summary

>- #113 
close #113 

## Tasks
- 프론트 측에서 기존 `/reservation/ticket` api에 세션명과 연사 이름 같이 전달을 요청하셔서 구현하였습니다.
- 결제 요청을 할 때 userId를 Dto에서 가져오는 것이 아닌 @Authentication 사용하여 가져오도록 변경하였습니다.
