### PR TITLE
[#118] 회원 탈퇴 로직

### DIFF
--- a/src/main/java/zoo/insightnote/domain/user/controller/UserController.java
+++ b/src/main/java/zoo/insightnote/domain/user/controller/UserController.java
@@ -10,12 +10,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import zoo.insightnote.domain.email.dto.request.EmailAuthRequest;
 import zoo.insightnote.domain.user.dto.request.JoinRequest;
 import zoo.insightnote.domain.user.dto.request.UserInfoRequest;
 import zoo.insightnote.domain.user.dto.response.PaymentUserInfoResponseDto;
+import zoo.insightnote.domain.user.dto.response.UserInfoResponse;
 
 @Tag(name = "USER", description = "유저 관련 API")
 public interface UserController {
@@ -34,6 +36,9 @@ public interface UserController {
 
     @Operation(summary = "마이페이지에서 본인 정보 수정", description = "유저정보에 저장된 내용을 수정합니다.")
     ResponseEntity<?> updateMyInfo(@Parameter(description = "수정할 부분만 넣어주세요.") @RequestBody UserInfoRequest userInfoRequest, @AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴시 이름과 닉네임을 익명 처리합니다.")
+    ResponseEntity<?> anonymizeMyInfo(@AuthenticationPrincipal UserDetails userDetails);
 
     @Operation(summary = "쿠키 기반 토큰을 헤더로 변환", description = "쿠키에 저장된 토큰을 헤더로 변환합니다.")
     ResponseEntity<?> convertTokenToHeader(@Parameter(description = "쿠키에 저장된 토큰") @CookieValue(value = "Authorization", required = false) String token);

--- a/src/main/java/zoo/insightnote/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/zoo/insightnote/domain/user/controller/UserControllerImpl.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -62,6 +63,12 @@ public class UserControllerImpl implements UserController {
     @PatchMapping("/me")
     public ResponseEntity<?> updateMyInfo(@RequestBody UserInfoRequest userInfoRequest, @AuthenticationPrincipal UserDetails userDetails) {
         UserInfoResponse userInfoResponse = userService.updateUserInfo(userInfoRequest, userDetails.getUsername());
+        return ResponseEntity.ok(userInfoResponse);
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<?> anonymizeMyInfo(@AuthenticationPrincipal UserDetails userDetails) {
+        UserInfoResponse userInfoResponse = userService.anonymizeUserInfo(userDetails.getUsername());
         return ResponseEntity.ok(userInfoResponse);
     }
 

--- a/src/main/java/zoo/insightnote/domain/user/entity/User.java
+++ b/src/main/java/zoo/insightnote/domain/user/entity/User.java
@@ -78,6 +78,12 @@ public class User {
         if (isChanged(this.snsUrl, snsUrl)) this.snsUrl = snsUrl;
     }
 
+    public void anonymizeUserData() {
+        this.username = null;
+        this.name = "알 수 없음";
+        this.nickname = "알 수 없음";
+    }
+
     private boolean isChanged(Object currentValue, Object newValue) {
         return newValue != null && !newValue.equals(currentValue);
     }

--- a/src/main/java/zoo/insightnote/domain/user/entity/User.java
+++ b/src/main/java/zoo/insightnote/domain/user/entity/User.java
@@ -23,7 +23,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true)
     private String username;
 
     private String name;

--- a/src/main/java/zoo/insightnote/domain/user/service/UserService.java
+++ b/src/main/java/zoo/insightnote/domain/user/service/UserService.java
@@ -102,4 +102,11 @@ public class UserService {
         );
         return userMapper.toResponse(user);
     }
+
+    @Transactional
+    public UserInfoResponse anonymizeUserInfo(String username) {
+        User user = findByUsername(username);
+        user.anonymizeUserData();
+        return userMapper.toResponse(user);
+    }
 }


### PR DESCRIPTION
## Summary

closed #118 

회원 탈퇴 로직 추가

## Tasks

- 회원 탈퇴 로직 추가
- 탈퇴 시 이름, 닉네임을 "알 수 없음"으로 변경
- 탈퇴 후 재가입 시 기존 데이터는 확인하지 못하기 때문에 탈퇴 시 username도 삭제 처리