### PR TITLE
[#127] 비회원에서 회원으로 전환 시 정보 연동

### DIFF
--- a/src/main/java/zoo/insightnote/domain/dummy/service/DummyUserService.java
+++ b/src/main/java/zoo/insightnote/domain/dummy/service/DummyUserService.java
@@ -3,7 +3,6 @@ package zoo.insightnote.domain.dummy.service;
 import lombok.RequiredArgsConstructor;
 import net.datafaker.Faker;
 import org.springframework.stereotype.Service;
-import zoo.insightnote.domain.user.entity.AuthProvider;
 import zoo.insightnote.domain.user.entity.Role;
 import zoo.insightnote.domain.user.entity.User;
 import zoo.insightnote.domain.user.repository.UserRepository;

--- a/src/main/java/zoo/insightnote/domain/dummy/service/DummyUserService.java
+++ b/src/main/java/zoo/insightnote/domain/dummy/service/DummyUserService.java
@@ -41,7 +41,6 @@ public class DummyUserService {
                     .occupation(OCCUPATIONS.get(faker.random().nextInt(OCCUPATIONS.size())))
                     .interestCategory(interests)
                     .role(faker.bool().bool() ? Role.USER : Role.GUEST)
-                    .provider(AuthProvider.GOOGLE)
                     .build();
 
             userRepository.save(user);

--- a/src/main/java/zoo/insightnote/domain/user/entity/AuthProvider.java
+++ b/src/main/java/zoo/insightnote/domain/user/entity/AuthProvider.java
@@ -1,7 +1,0 @@
-package zoo.insightnote.domain.user.entity;
-
-public enum AuthProvider {
-    KAKAO,
-    GOOGLE,
-    NONE // 비회원 (Guest)
-}

--- a/src/main/java/zoo/insightnote/domain/user/entity/User.java
+++ b/src/main/java/zoo/insightnote/domain/user/entity/User.java
@@ -1,5 +1,7 @@
 package zoo.insightnote.domain.user.entity;
 
+import static zoo.insightnote.domain.user.entity.Role.*;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -43,9 +45,6 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @Enumerated(EnumType.STRING)
-    private AuthProvider provider;
-
     private String snsUrl;
 
     public User(String username, String name, String email, Role role) {
@@ -53,6 +52,11 @@ public class User {
         this.name = name;
         this.email = email;
         this.role = role;
+    }
+
+    public void updateUsername(String username) {
+        this.username = username;
+        this.role = USER;
     }
 
     public void update(String email, String name) {

--- a/src/main/java/zoo/insightnote/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/zoo/insightnote/domain/user/service/CustomOAuth2UserService.java
@@ -33,7 +33,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         OAuth2Response oAuth2Response = getOAuth2User(registrationId, oAuth2User);
 
         String username = oAuth2Response.getProvider() + " " + oAuth2Response.getProviderId();
-        User existData = userRepository.findByUsername(username).orElse(null);
+        String email = oAuth2Response.getEmail();
+        User existData = userRepository.findByUsername(email)
+                .orElseGet(() -> userRepository.findByUsername(username).orElse(null));
         return saveOAuth2User(existData, username, oAuth2Response);
     }
 
@@ -57,6 +59,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         }
 
         // existData.update(oAuth2Response.getEmail(), oAuth2Response.getName());
+        existData.updateUsername(username);
 
         UserDto userDto = UserDto.builder()
                 .username(username)


### PR DESCRIPTION
## Summary

closed #127 
비회원에서 회원으로 전환 시 비회원 시 인증 받은 이메일과 회원으로 가입할 때의 이메일이 같다면 정보가 연동되도록 하였음.

## Tasks

- 비회원에서 회원으로 전환 시 정보 연동
- 사용하지 않는 provider 필드 삭제
